### PR TITLE
TA-2491 modify regex to handle more links

### DIFF
--- a/src/client/components/atoms/text-section/text-section.jsx
+++ b/src/client/components/atoms/text-section/text-section.jsx
@@ -66,7 +66,10 @@ class TextSection extends React.Component {
       })
     })
     $('a').each((i, anchor) => {
-      if (anchor.attribs.href && !/https?:\/\/[a-zA-Z.0-9]+?\.gov\/.*/.test(anchor.attribs.href)) {
+      if (
+        anchor.attribs.href &&
+        !/(https?:\/\/[a-zA-Z.0-9]+?\.gov($|(\/.*)))|^\//.test(anchor.attribs.href)
+      ) {
         $(anchor).addClass('external-link-marker')
       }
     })

--- a/src/client/components/atoms/text-section/text-section.jsx
+++ b/src/client/components/atoms/text-section/text-section.jsx
@@ -66,6 +66,8 @@ class TextSection extends React.Component {
       })
     })
     $('a').each((i, anchor) => {
+      // Regex will check for .gov link without a path or with a path OR a relative link.
+      // If none of the above cases are true then we add an external-link-marker class to the link.
       if (
         anchor.attribs.href &&
         !/(https?:\/\/[a-zA-Z.0-9]+?\.gov($|(\/.*)))|^\//.test(anchor.attribs.href)


### PR DESCRIPTION
Can currently be observed in amy.ussba.io
Example of basic page with .gov link, relative link, and external non-.gov link (accredited registrars link near bottom of page):
https://amy.ussba.io/business-guide/launch-your-business/choose-your-business-name