### PR TITLE
TA-2486 add styles for link color in text section

### DIFF
--- a/src/client/components/atoms/text-section/text-section.scss
+++ b/src/client/components/atoms/text-section/text-section.scss
@@ -70,6 +70,14 @@
   background-size: 100%;
 }
 
+.textSection a {
+  color: $secondary-blue;
+
+  &:hover {
+    color: $secondary-blue-light;
+  }
+}
+
 @include grid-media($sba-grid-small) {
   :global(.text-section-table) {
     & thead > tr {


### PR DESCRIPTION
Can be viewed in amy.ussba.io on any basic page.
Example of page with external link that now matches color of internal links: http://amy.ussba.io/business-guide/launch-your-business/choose-your-business-name and go near bottom of the page to view `accredited registrars` link.