### PR TITLE
TA-2922 added no-results state and unit test

### DIFF
--- a/src/client/components/molecules/quick-links/quick-links.jsx
+++ b/src/client/components/molecules/quick-links/quick-links.jsx
@@ -36,13 +36,22 @@ const valueOrAll = value => {
 class QuickLinks extends PureComponent {
   constructor(props) {
     super(props)
-    this.state = { articles: [], documents: [] }
+    this.state = {
+      articles: [],
+      documents: [],
+      LOADING_STATE: 'unloaded'
+    }
   }
 
   async componentDidMount() {
     this.setState({
-      documents: await this.fetchDocuments(),
-      articles: await this.fetchArticles()
+      LOADING_STATE: 'isLoading'
+    }, async () => {
+      this.setState({
+        documents: await this.fetchDocuments(),
+        articles: await this.fetchArticles(),
+        LOADING_STATE: 'isLoaded'
+      })
     })
   }
 
@@ -98,7 +107,7 @@ class QuickLinks extends PureComponent {
     const {
       data: { typeOfLinks }
     } = this.props
-    const { documents, articles } = this.state
+    const { documents, articles, LOADING_STATE } = this.state
     const gridClass = this.generateGrid(typeOfLinks.length)
 
     return typeOfLinks.map((quickLink, index) => {
@@ -108,6 +117,7 @@ class QuickLinks extends PureComponent {
             key={index}
             className={styles.card + ' ' + gridClass}
             documents={documents['documents-' + index]}
+            LOADING_STATE={LOADING_STATE}
             {...quickLink}
           />
         )
@@ -131,7 +141,7 @@ class QuickLinks extends PureComponent {
   render() {
     return (
       <div className={styles.collection} data-testid="quick-links">
-        {this.props.data ? this.renderQuickLinks() : <div>loading</div>}
+        {this.props.data ? this.renderQuickLinks() : <div>loading A</div>}
       </div>
     )
   }
@@ -139,6 +149,7 @@ class QuickLinks extends PureComponent {
 
 const LatestDocumentsCard = props => {
   const eventCategory = `${props.sectionHeaderText.toLowerCase()}-module`
+  const { LOADING_STATE } = props
   return (
     <div data-testid="documents-card" className={props.className}>
       <div className={styles.titleContainer}>
@@ -158,41 +169,44 @@ const LatestDocumentsCard = props => {
       </div>
       <DecorativeDash width={30} />
       <div>
-        {!isEmpty(props.documents) && props.documents.items.length ? (
-          props.documents.items.map((doc, index) => {
-            const currentFile = getCurrentFile(doc.files)
-            let effectiveDate
-            if (currentFile && currentFile.effectiveDate) {
-              effectiveDate = currentFile.effectiveDate
-            }
+        {LOADING_STATE === 'isLoading' && <div>loading</div>}
+        {LOADING_STATE === 'isLoaded' && <div>
+          {!isEmpty(props.documents) && props.documents.items.length > 0 ? (
+            props.documents.items.map((doc, index) => {
+              const currentFile = getCurrentFile(doc.files)
+              let effectiveDate
+              if (currentFile && currentFile.effectiveDate) {
+                effectiveDate = currentFile.effectiveDate
+              }
 
-            // Add a prefix to SOPs with the format {DOC_TYPE} {DOC_NUMBER} ({DOC_VERSION}) - {DOC_TITLE}
-            let titlePrefix = ''
-            if (doc.documentIdType === 'SOP' && !isEmpty(doc.documentIdNumber)) {
-              titlePrefix = doc.documentIdType + ' ' + doc.documentIdNumber + ' - '
-            }
-            const linkTitle =
-              /* eslint-disable-next-line no-magic-number */
-              titlePrefix +
-              (doc.title.length > MAX_TITLE_LENGTH
-                ? doc.title.slice(0, MAX_TITLE_LENGTH + 10) + '...'
-                : doc.title)
-            return (
-              <div key={index}>
-                <Link data-testid="document-link" to={doc.url}>
-                  {linkTitle}
-                </Link>
-                {effectiveDate && (
-                  <div data-testid="document-date" className={styles.date}>
-                    {formatDate(effectiveDate)}
-                  </div>
-                )}
-              </div>
-            )
-          })
-        ) : (
-          <div>loading</div>
-        )}
+              // Add a prefix to SOPs with the format {DOC_TYPE} {DOC_NUMBER} ({DOC_VERSION}) - {DOC_TITLE}
+              let titlePrefix = ''
+              if (doc.documentIdType === 'SOP' && !isEmpty(doc.documentIdNumber)) {
+                titlePrefix = doc.documentIdType + ' ' + doc.documentIdNumber + ' - '
+              }
+              const linkTitle =
+                /* eslint-disable-next-line no-magic-number */
+                titlePrefix +
+                (doc.title.length > MAX_TITLE_LENGTH
+                  ? doc.title.slice(0, MAX_TITLE_LENGTH + 10) + '...'
+                  : doc.title)
+              return (
+                <div key={index}>
+                  <Link data-testid="document-link" to={doc.url}>
+                    {linkTitle}
+                  </Link>
+                  {effectiveDate && (
+                    <div data-testid="document-date" className={styles.date}>
+                      {formatDate(effectiveDate)}
+                    </div>
+                  )}
+                </div>
+              )
+            })
+          ) : (
+            <div data-testid="no-results">no documents found</div>
+          )}
+          </div>}
       </div>
     </div>
   )

--- a/src/client/components/molecules/quick-links/quick-links.jsx
+++ b/src/client/components/molecules/quick-links/quick-links.jsx
@@ -204,7 +204,7 @@ const LatestDocumentsCard = props => {
               )
             })
           ) : (
-            <div data-testid="no-results">no documents found</div>
+            <div data-testid="no-results">No documents found</div>
           )}
           </div>}
       </div>

--- a/src/client/components/molecules/quick-links/quick-links.jsx
+++ b/src/client/components/molecules/quick-links/quick-links.jsx
@@ -141,7 +141,7 @@ class QuickLinks extends PureComponent {
   render() {
     return (
       <div className={styles.collection} data-testid="quick-links">
-        {this.props.data ? this.renderQuickLinks() : <div>loading A</div>}
+        {this.props.data ? this.renderQuickLinks() : <div>loading</div>}
       </div>
     )
   }

--- a/src/client/components/molecules/quick-links/quick-links.jsx
+++ b/src/client/components/molecules/quick-links/quick-links.jsx
@@ -169,7 +169,7 @@ const LatestDocumentsCard = props => {
       </div>
       <DecorativeDash width={30} />
       <div>
-        {LOADING_STATE === 'isLoading' && <div>loading</div>}
+        {LOADING_STATE === 'isLoading' && <div>Loading</div>}
         {LOADING_STATE === 'isLoaded' && <div>
           {!isEmpty(props.documents) && props.documents.items.length > 0 ? (
             props.documents.items.map((doc, index) => {

--- a/test/jest/client/components/molecules/quick-links/__snapshots__/quick-links.test.js.snap
+++ b/test/jest/client/components/molecules/quick-links/__snapshots__/quick-links.test.js.snap
@@ -37,7 +37,7 @@ exports[`QuickLinks snapshot tests Future effective date is not displayed 1`] = 
     />
     <div>
       <div>
-        loading
+        Loading
       </div>
     </div>
   </div>
@@ -81,7 +81,7 @@ exports[`QuickLinks snapshot tests Most recent effective date displayed 1`] = `
     />
     <div>
       <div>
-        loading
+        Loading
       </div>
     </div>
   </div>
@@ -125,7 +125,7 @@ exports[`QuickLinks snapshot tests No SOP number so it is not displayed 1`] = `
     />
     <div>
       <div>
-        loading
+        Loading
       </div>
     </div>
   </div>
@@ -169,7 +169,7 @@ exports[`QuickLinks snapshot tests SOP number exists and is displayed 1`] = `
     />
     <div>
       <div>
-        loading
+        Loading
       </div>
     </div>
   </div>

--- a/test/jest/client/components/molecules/quick-links/quick-links.test.js
+++ b/test/jest/client/components/molecules/quick-links/quick-links.test.js
@@ -465,4 +465,33 @@ describe('Quick Links unit tests', () => {
 
     mockFetchSiteContent.mockReset()
   })
+  test('should not have any document links because no documents have returned', async () => {
+    const mockPropsData = {
+      type: 'quickLinks',
+      typeOfLinks: [
+        {
+          documentActivity: [],
+          documentProgram: [],
+          documentType: [],
+          type: 'documentLookup',
+          documentOffice: 3000,
+          sectionHeaderText: 'Document List for Office'
+        }
+      ]
+    }
+
+    const mockResponse = {
+      count: 0,
+      items: []
+    }
+
+    const mockFetchSiteContent = jest.spyOn(fetchContentHelper, 'fetchSiteContent')
+    mockFetchSiteContent.mockReturnValue(mockResponse)
+
+    const { getByTestId } = render(<QuickLinks data={mockPropsData} />)
+    const content = await waitForElement(() => getByTestId('no-results'))
+    expect(content).toBeInTheDocument()
+
+    mockFetchSiteContent.mockReset()
+  })
 })


### PR DESCRIPTION
for jira ticket https://us-sba.atlassian.net/browse/TA-2922

- [x] a ‘no results’ message displays when no results are returned, to replace persistent loading message.