### PR TITLE
TA-3005 use featured image for posts on blog category page

### DIFF
--- a/src/client/components/pages/blog-category/blog-category-page.jsx
+++ b/src/client/components/pages/blog-category/blog-category-page.jsx
@@ -123,9 +123,10 @@ class BlogCategoryPage extends Component {
       titleText: blog.title
     }
 
-    if (typeof blog.featuredImage === 'string' && blog.featuredImage.length > 0) {
+    if (!isEmpty(blog.featuredImage)) {
       reformattedBlog.image = {
-        url: blog.featuredImage
+        url: blog.featuredImage.url,
+        alt: blog.featuredImage.alt
       }
     }
 

--- a/src/client/components/pages/blog-category/blog-category-page.jsx
+++ b/src/client/components/pages/blog-category/blog-category-page.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import moment from 'moment'
+import { isEmpty } from 'lodash'
 
 import { Paginator } from 'molecules'
 import { CardCollection } from 'organisms'
@@ -112,7 +113,7 @@ class BlogCategoryPage extends Component {
   }
 
   reformatBlog(blog) {
-    return {
+    const reformattedBlog = {
       italicText: moment.unix(blog.created).format('MMMM D, YYYY'),
       link: {
         title: 'Read full post',
@@ -121,6 +122,14 @@ class BlogCategoryPage extends Component {
       subtitleText: blog.summary,
       titleText: blog.title
     }
+
+    if (typeof blog.featuredImage === 'string' && blog.featuredImage.length > 0) {
+      reformattedBlog.image = {
+        url: blog.featuredImage
+      }
+    }
+
+    return reformattedBlog
   }
 
   onBack() {

--- a/test/jest/client/components/pages/blog-category/blog-category.test.js
+++ b/test/jest/client/components/pages/blog-category/blog-category.test.js
@@ -1,7 +1,7 @@
 /*eslint-disable no-undefined*/
 
 import React from 'react'
-import { render, cleanup, waitForElement, fireEvent } from 'react-testing-library'
+import { render, cleanup, waitForElement, fireEvent, within } from 'react-testing-library'
 import { Provider } from 'react-redux'
 import { createStore, applyMiddleware } from 'redux'
 import thunk from 'redux-thunk'
@@ -49,7 +49,7 @@ describe('Blog Category Page', () => {
         expect(subtitle).toHaveTextContent(blogCategory.subtitle)
       })
 
-      it('will get the blog posts for ' + blogCategory.title, async () => {
+      it('will get the blog posts for ' + blogCategory.title, done => {
         const fetchSiteContentStub = jest.spyOn(fetchContentHelper, 'fetchSiteContent')
 
         const mockBlogResponse = {
@@ -71,81 +71,111 @@ describe('Blog Category Page', () => {
           end: 12
         }
 
-        const blogPosts = await waitForElement(() => getByTestId('blog-card-collections'))
-        const blogCards = await waitForElement(() => findAllByTestId('card'))
-        const topPaginator = await waitForElement(() => getByTestId('blog-top-paginator'))
-        const bottomPaginator = await waitForElement(() => getByTestId('blog-bottom-paginator'))
-        expect(blogPosts).toBeInTheDocument()
-        expect(blogCards).toHaveLength(12)
-        expect(topPaginator).toBeInTheDocument()
-        expect(bottomPaginator).toBeInTheDocument()
-        expect(fetchSiteContentStub).toBeCalledWith('blogs', firstQueryParams)
+        setImmediate(async () => {
+          const blogPosts = await waitForElement(() => getByTestId('blog-card-collections'))
+          const blogCards = await waitForElement(() => findAllByTestId('card'))
+          const topPaginator = await waitForElement(() => getByTestId('blog-top-paginator'))
+          const bottomPaginator = await waitForElement(() => getByTestId('blog-bottom-paginator'))
+          expect(blogPosts).toBeInTheDocument()
+          expect(blogCards).toHaveLength(12)
+          expect(topPaginator).toBeInTheDocument()
+          expect(bottomPaginator).toBeInTheDocument()
+          expect(fetchSiteContentStub).toBeCalledWith('blogs', firstQueryParams)
+          done()
+        })
       })
 
-      it(
-        'will properly paginate the and make the appropriate requests for ' + blogCategory.title,
-        async () => {
-          const fetchSiteContentStub = jest.spyOn(fetchContentHelper, 'fetchSiteContent')
+      it('will properly paginate the and make the appropriate requests for ' + blogCategory.title, done => {
+        const fetchSiteContentStub = jest.spyOn(fetchContentHelper, 'fetchSiteContent')
 
-          const mockFirstBlogResponse = {
-            response: 200,
-            data: {
-              total: 20,
-              blogs: blogQueryResponse(12, 'newer blogs')
-            }
+        const mockFirstBlogResponse = {
+          response: 200,
+          data: {
+            total: 20,
+            blogs: blogQueryResponse(12, 'newer blogs')
           }
-          const mockSecondBlogResponse = {
-            response: 200,
-            data: {
-              total: 20,
-              blogs: blogQueryResponse(8, 'older blogs')
-            }
-          }
-          axiosMock.get.mockResolvedValueOnce(mockFirstBlogResponse)
-
-          const { getAllByTestId, findAllByTestId, findAllByText } = render(
-            <BlogCategoryPage params={{ category: blogCategory.name }} />
-          )
-
-          const firstQueryParams = {
-            category: blogCategory.queryTerm,
-            start: 0,
-            end: 12
-          }
-          const secondQueryParams = {
-            category: blogCategory.queryTerm,
-            start: 12,
-            end: 24
-          }
-
-          setImmediate(async () => {
-
-            let blogCards = await waitForElement(() => findAllByTestId('card'))
-            const forwardButton = await waitForElement(() => getAllByTestId('next button')[0])
-            const backwardButton = await waitForElement(() => getAllByTestId('previous button')[0])
-
-            expect(fetchSiteContentStub).toBeCalledWith('blogs', firstQueryParams)
-            expect(blogCards).toHaveLength(12)
-
-            axiosMock.get.mockResolvedValueOnce(mockSecondBlogResponse)
-            fireEvent.click(forwardButton)
-            expect(fetchSiteContentStub).toBeCalledWith('blogs', secondQueryParams)
-            await waitForElement(() => findAllByText('older blogs'))
-            blogCards = await waitForElement(() => findAllByTestId('card'))
-            expect(blogCards).toHaveLength(8)
-
-            axiosMock.get.mockResolvedValueOnce(mockFirstBlogResponse)
-            fireEvent.click(backwardButton)
-            expect(fetchSiteContentStub).toBeCalledWith('blogs', firstQueryParams)
-            await waitForElement(() => findAllByText('newer blogs'))
-            blogCards = await waitForElement(() => findAllByTestId('card'))
-            expect(blogCards).toHaveLength(12)
-
-          })
-
         }
-      )
+        const mockSecondBlogResponse = {
+          response: 200,
+          data: {
+            total: 20,
+            blogs: blogQueryResponse(8, 'older blogs')
+          }
+        }
+        axiosMock.get.mockResolvedValueOnce(mockFirstBlogResponse)
+
+        const { getAllByTestId, findAllByTestId, findAllByText } = render(
+          <BlogCategoryPage params={{ category: blogCategory.name }} />
+        )
+
+        const firstQueryParams = {
+          category: blogCategory.queryTerm,
+          start: 0,
+          end: 12
+        }
+        const secondQueryParams = {
+          category: blogCategory.queryTerm,
+          start: 12,
+          end: 24
+        }
+
+        setImmediate(async () => {
+          let blogCards = await waitForElement(() => findAllByTestId('card'))
+          const forwardButton = await waitForElement(() => getAllByTestId('next button')[0])
+          const backwardButton = await waitForElement(() => getAllByTestId('previous button')[0])
+
+          expect(fetchSiteContentStub).toBeCalledWith('blogs', firstQueryParams)
+          expect(blogCards).toHaveLength(12)
+
+          axiosMock.get.mockResolvedValueOnce(mockSecondBlogResponse)
+          fireEvent.click(forwardButton)
+          expect(fetchSiteContentStub).toBeCalledWith('blogs', secondQueryParams)
+          await waitForElement(() => findAllByText('older blogs'))
+          blogCards = await waitForElement(() => findAllByTestId('card'))
+          expect(blogCards).toHaveLength(8)
+
+          axiosMock.get.mockResolvedValueOnce(mockFirstBlogResponse)
+          fireEvent.click(backwardButton)
+          expect(fetchSiteContentStub).toBeCalledWith('blogs', firstQueryParams)
+          await waitForElement(() => findAllByText('newer blogs'))
+          blogCards = await waitForElement(() => findAllByTestId('card'))
+          expect(blogCards).toHaveLength(12)
+          done()
+        })
+      })
     })
+  })
+
+  it('displays a featured image on the blog card when it exists', done => {
+    const blogCategory = 'success-stories'
+    const mockBlogWithFeaturedImage = {
+      title: 'Some Title',
+      featuredImage: {
+        url: '/foo',
+        alt: 'foo text'
+      }
+    }
+    const mockBlogsResponse = {
+      total: 1,
+      blogs: [mockBlogWithFeaturedImage]
+    }
+
+    const fetchSiteContentStub = jest.spyOn(fetchContentHelper, 'fetchSiteContent')
+    when(fetchSiteContentStub)
+      .calledWith('blogs')
+      .mockImplementationOnce(() => mockBlogsResponse)
+
+    const { getByTestId } = render(<BlogCategoryPage params={{ category: blogCategory }} />)
+
+    setImmediate(async () => {
+      const blogCard = await waitForElement(() => getByTestId('card'))
+      const cardImage = within(blogCard).getByTestId('card image')
+      expect(cardImage).toHaveAttribute('alt', mockBlogWithFeaturedImage.featuredImage.alt)
+      expect(cardImage).toHaveAttribute('src', mockBlogWithFeaturedImage.featuredImage.url)
+      done()
+    })
+
+    fetchSiteContentStub.mockRestore()
   })
 
   describe('when visiting a blog category type for an office', () => {


### PR DESCRIPTION
- [x] `featuredImage` used for blog post cards on blog category page

Example: https://amy.ussba.io/blogs/success-stories/19527/

Note: Needed to update existing tests in the blog category test suite to scope portions within setImmediate blocks