### PR TITLE
TA-3298 remove unnecessary ids

### DIFF
--- a/src/client/components/atoms/card-container/card-container.jsx
+++ b/src/client/components/atoms/card-container/card-container.jsx
@@ -4,7 +4,7 @@ import classNames from 'classnames'
 import styles from './card-container.scss'
 
 const CardContainer = props => {
-  const { cardContent, cardAriaLabel, index, numCards, parentIndex } = props
+  const { cardContent, cardAriaLabel, index, numCards } = props
 
   /* eslint-disable no-magic-numbers */
   const className = classNames({
@@ -22,7 +22,6 @@ const CardContainer = props => {
   return (
     <div
       data-testid="card-container"
-      id={`card-${parentIndex}-${index + 1}`}
       aria-label={`${cardAriaLabel} ${index + 1}`}
       tabIndex="0"
       className={className}
@@ -36,16 +35,14 @@ CardContainer.defaultProps = {
   cardAriaLabel: 'card',
   item: {},
   index: -1,
-  numCards: -1,
-  parentIndex: -1
+  numCards: -1
 }
 
 CardContainer.propTypes = {
   cardContent: PropTypes.element.isRequired,
   cardAriaLabel: PropTypes.string,
   index: PropTypes.number,
-  numCards: PropTypes.number,
-  parentIndex: PropTypes.number
+  numCards: PropTypes.number
 }
 
 export default CardContainer

--- a/src/client/components/organisms/generic-card-collection/generic-card-collection.jsx
+++ b/src/client/components/organisms/generic-card-collection/generic-card-collection.jsx
@@ -25,13 +25,12 @@ class GenericCardCollection extends React.Component {
     this.state = {}
   }
   render() {
-    const { leftAligned, parentIndex, cardsContent, numberOverride, cardAriaLabel } = this.props
+    const { leftAligned, cardsContent, numberOverride, cardAriaLabel } = this.props
     const numCards = numberOverride ? numberOverride : size(this.props.cardsContent)
     const cardComponents = cardsContent.map(function(cardContent, index) {
       return (
         <CardContainer
           cardContent={cardContent}
-          parentIndex={parentIndex}
           key={index}
           index={index}
           numCards={numCards}
@@ -47,7 +46,7 @@ class GenericCardCollection extends React.Component {
       <div data-testid="generic-card-collection" className={styles.cardCollection}>
         {rows.map(function(item, index) {
           return (
-            <div id={'card-row-' + parentIndex + '-' + index} key={index} className={styles.cardRow}>
+            <div key={index} className={styles.cardRow}>
               {item}
             </div>
           )
@@ -61,14 +60,12 @@ GenericCardCollection.propTypes = {
   cardAriaLabel: PropTypes.string,
   cardsContent: PropTypes.arrayOf(PropTypes.element),
   numberOverride: PropTypes.number,
-  parentIndex: PropTypes.number,
   leftAligned: PropTypes.bool
 }
 
 GenericCardCollection.defaultProps = {
   cardsContent: [],
   numberOverride: null,
-  parentIndex: -1,
   leftAligned: false
 }
 


### PR DESCRIPTION
Changes are updated in amy's environment.

Compare axe id errors for location info cards in mint versus resolved errors in amy.
https://amy.ussba.io/offices/district/6472/
https://mint.ussba.io/offices/district/19586/

Errors seen in mint:
- IDs of active elements must be unique
- id attribute value must be unique