### PR TITLE
TA-3294 update news releases query params

### DIFF
--- a/src/client/components/organisms/news-releases/news-releases.jsx
+++ b/src/client/components/organisms/news-releases/news-releases.jsx
@@ -14,14 +14,21 @@ class NewsReleases extends React.Component {
   }
 
   async componentDidMount() {
-    const { officeId } = this.props
-    const { items } = await fetchSiteContent('articles', {
-      office: officeId,
+    const { officeId, national, region } = this.props
+
+    const queryParams = {
       articleCategory: 'Press release',
       sortBy: 'Last Updated',
       start: 0,
       end: 3
-    })
+    }
+
+    // if these optional props were passed in, then add them as query params
+    officeId && (queryParams.office = officeId)
+    national && (queryParams.national = national)
+    region && (queryParams.region = region)
+
+    const { items } = await fetchSiteContent('articles', queryParams)
     const articles = items
     this.setState({ articles })
   }
@@ -54,7 +61,9 @@ class NewsReleases extends React.Component {
 }
 
 NewsReleases.propTypes = {
-  officeId: PropTypes.number
+  officeId: PropTypes.number,
+  national: PropTypes.bool,
+  region: PropTypes.string
 }
 
 export default NewsReleases

--- a/src/client/components/organisms/news-releases/news-releases.jsx
+++ b/src/client/components/organisms/news-releases/news-releases.jsx
@@ -17,6 +17,10 @@ class NewsReleases extends React.Component {
     const { officeId, national, region } = this.props
 
     const queryParams = {
+      // mode: 'districtOffice' utilizes content api's feature flag to find articles via cloudsearch
+      // when/if the content api combines search functionality for articles into one place,
+      // then this query param can be removed
+      mode: 'districtOffice',
       articleCategory: 'Press release',
       sortBy: 'Last Updated',
       start: 0,
@@ -24,7 +28,7 @@ class NewsReleases extends React.Component {
     }
 
     // if these optional props were passed in, then add them as query params
-    officeId && (queryParams.office = officeId)
+    officeId && (queryParams.relatedOffice = officeId)
     national && (queryParams.national = national)
     region && (queryParams.region = region)
 

--- a/src/client/components/templates/district-office/district-office.jsx
+++ b/src/client/components/templates/district-office/district-office.jsx
@@ -53,6 +53,7 @@ class DistrictOfficeTemplate extends React.Component {
     const { events, leaders } = this.state
     const { office } = this.props
     const { twitterLink } = office
+    const officeRegion = !isEmpty(office.region) ? office.region : null
 
     return (
       <div>
@@ -81,7 +82,7 @@ class DistrictOfficeTemplate extends React.Component {
           </div>
         </div>
         <div className={styles.section} data-testid="news-release-section">
-          <NewsReleases officeId={office.id} />
+          <NewsReleases officeId={office.id} national={true} region={officeRegion} />
         </div>
         <div className={styles.content}>
           <div className={styles.section}>

--- a/test/jest/client/components/organisms/news-releases/news-releases.test.js
+++ b/test/jest/client/components/organisms/news-releases/news-releases.test.js
@@ -74,7 +74,8 @@ describe('News releases', () => {
     const officeRegion = 'Region I'
 
     const expectedQueryParams = {
-      office: officeId,
+      mode: 'districtOffice',
+      relatedOffice: officeId,
       articleCategory: 'Press release',
       national: true,
       region: officeRegion,
@@ -94,6 +95,7 @@ describe('News releases', () => {
     fetchSiteContentStub.mockImplementationOnce(() => Promise.resolve(oneNewsReleaseData))
 
     const expectedQueryParams = {
+      mode: 'districtOffice',
       articleCategory: 'Press release',
       sortBy: 'Last Updated',
       start: 0,

--- a/test/jest/client/components/organisms/news-releases/news-releases.test.js
+++ b/test/jest/client/components/organisms/news-releases/news-releases.test.js
@@ -3,6 +3,7 @@ import { render, cleanup, waitForElement } from 'react-testing-library'
 import { NewsReleases } from 'organisms'
 import 'jest-dom/extend-expect'
 import * as fetchContentHelper from 'client/fetch-content-helper.js'
+import { remapArticlesToBetterSchema } from '../../../../../../src/client/components/organisms/news-releases/news-releases.jsx'
 
 import noNewsReleaseData from '../../test-data/news-releases/noNewsReleasesData.json'
 import oneNewsReleaseData from '../../test-data/news-releases/oneNewsReleasesData.json'
@@ -107,4 +108,145 @@ describe('News releases', () => {
 
     expect(fetchSiteContentStub).toHaveBeenCalledWith('articles', expectedQueryParams)
   })
+
+  /* eslint-disable no-magic-numbers */
+  describe('remapArticlesToBetterSchema function', () => {
+    it('should remap an object when all fields are present', () => {
+      const inputArticles = [
+        {
+          id: '20351',
+          fields: {
+            article_category: ['Press release'],
+            office: ['6422'],
+            article_programs: ['7(a)'],
+            region: ['National (all regions)'],
+            related_offices: ['17054'],
+            summary: ['summary text'],
+            title: ['CST Article 2 (single input fields)'],
+            created: ['1574192414'],
+            updated: ['1574192835'],
+            url: ['/article/2019/nov/19/cst-article-2-single-input-fields']
+          }
+        }
+      ]
+
+      const expected = [
+        {
+          id: 20351,
+          category: ['Press release'],
+          office: 6422,
+          programs: ['7(a)'],
+          region: ['National (all regions)'],
+          relatedOffices: [17054],
+          summary: 'summary text',
+          type: 'article',
+          title: 'CST Article 2 (single input fields)',
+          created: 1574192414,
+          updated: 1574192835,
+          url: '/article/2019/nov/19/cst-article-2-single-input-fields'
+        }
+      ]
+
+      const result = remapArticlesToBetterSchema(inputArticles)
+      expect(result).toStrictEqual(expected)
+    })
+
+    it('should remap an object with default values when any field is NOT present', () => {
+      const inputArticles = [
+        {
+          id: '20351',
+          fields: {}
+        }
+      ]
+
+      const expected = [
+        {
+          id: 20351,
+          category: [],
+          office: {},
+          programs: [],
+          region: [],
+          relatedOffices: [],
+          summary: '',
+          type: 'article',
+          title: '',
+          created: {},
+          updated: {},
+          url: ''
+        }
+      ]
+
+      const result = remapArticlesToBetterSchema(inputArticles)
+      expect(result).toStrictEqual(expected)
+    })
+
+    it('should remap an object with stringified numbers converted to numbers for certain fields', () => {
+      const inputArticles = [
+        {
+          id: '20351',
+          fields: {
+            office: ['6422'],
+            related_offices: ['17054', '23566'],
+            created: ['1574192414'],
+            updated: ['1574192835']
+          }
+        }
+      ]
+
+      const expected = [
+        {
+          id: 20351,
+          category: [],
+          office: 6422,
+          programs: [],
+          region: [],
+          relatedOffices: [17054, 23566],
+          summary: '',
+          type: 'article',
+          title: '',
+          created: 1574192414,
+          updated: 1574192835,
+          url: ''
+        }
+      ]
+
+      const result = remapArticlesToBetterSchema(inputArticles)
+      expect(result).toStrictEqual(expected)
+    })
+
+    it('should remap an object while preserving arrays for certain fields', () => {
+      const inputArticles = [
+        {
+          id: '20351',
+          fields: {
+            article_category: ['Notice', 'Press release'],
+            article_programs: ['7(a)', '8(a)'],
+            region: ['Region I', 'Region V'],
+            related_offices: ['17054', '23566']
+          }
+        }
+      ]
+
+      const expected = [
+        {
+          id: 20351,
+          category: ['Notice', 'Press release'],
+          office: {},
+          programs: ['7(a)', '8(a)'],
+          region: ['Region I', 'Region V'],
+          relatedOffices: [17054, 23566],
+          summary: '',
+          type: 'article',
+          title: '',
+          created: {},
+          updated: {},
+          url: ''
+        }
+      ]
+
+      const result = remapArticlesToBetterSchema(inputArticles)
+      expect(result).toStrictEqual(expected)
+    })
+  })
+  /* eslint-enable no-magic-numbers */
 })

--- a/test/jest/client/components/organisms/news-releases/news-releases.test.js
+++ b/test/jest/client/components/organisms/news-releases/news-releases.test.js
@@ -9,11 +9,23 @@ import oneNewsReleaseData from '../../test-data/news-releases/oneNewsReleasesDat
 import threeNewsReleaseData from '../../test-data/news-releases/threeNewsReleasesData.json'
 import errorNewsReleaseData from '../../test-data/news-releases/errorNewsReleasesData.json'
 
-afterEach(cleanup)
+let fetchSiteContentStub
+
+beforeEach(function() {
+  fetchSiteContentStub = jest.spyOn(fetchContentHelper, 'fetchSiteContent')
+})
+
+afterEach(function() {
+  fetchSiteContentStub.mockReset()
+  cleanup()
+})
+
+afterAll(function() {
+  fetchSiteContentStub.mockRestore()
+})
 
 describe('News releases', () => {
   it('renders nothing when NO news releases are found', async () => {
-    const fetchSiteContentStub = jest.spyOn(fetchContentHelper, 'fetchSiteContent')
     fetchSiteContentStub.mockImplementationOnce(() => Promise.resolve(noNewsReleaseData))
 
     const { queryByTestId } = render(<NewsReleases officeId={12345} />)
@@ -22,7 +34,6 @@ describe('News releases', () => {
     expect(queryByTestId('news-more-button')).toBeNull()
   })
   it('renders only 1 news release card when only 1 news release is returned', async () => {
-    const fetchSiteContentStub = jest.spyOn(fetchContentHelper, 'fetchSiteContent')
     fetchSiteContentStub.mockImplementationOnce(() => Promise.resolve(oneNewsReleaseData))
 
     const { getByTestId } = render(<NewsReleases officeId={12345} />)
@@ -35,7 +46,6 @@ describe('News releases', () => {
     expect(newsButton).toHaveTextContent('View All')
   })
   it('renders the full listing when 3 news releases are found', async () => {
-    const fetchSiteContentStub = jest.spyOn(fetchContentHelper, 'fetchSiteContent')
     fetchSiteContentStub.mockImplementationOnce(() => Promise.resolve(threeNewsReleaseData))
 
     const { getByTestId, getAllByTestId } = render(<NewsReleases officeId={12345} />)
@@ -50,12 +60,49 @@ describe('News releases', () => {
     expect(newsButton).toHaveTextContent('View All')
   })
   it('renders nothing when the news release request fails', () => {
-    const fetchSiteContentStub = jest.spyOn(fetchContentHelper, 'fetchSiteContent')
     fetchSiteContentStub.mockImplementationOnce(() => Promise.resolve(errorNewsReleaseData))
 
     const { queryByTestId } = render(<NewsReleases officeId={12345} />)
 
     expect(queryByTestId('news-cards')).toBeNull()
     expect(queryByTestId('news-more-button')).toBeNull()
+  })
+  it('includes officeId, national, and region query parameters in the fetch call when they exist as props', async () => {
+    fetchSiteContentStub.mockImplementationOnce(() => Promise.resolve(oneNewsReleaseData))
+
+    const officeId = 12345
+    const officeRegion = 'Region I'
+
+    const expectedQueryParams = {
+      office: officeId,
+      articleCategory: 'Press release',
+      national: true,
+      region: officeRegion,
+      sortBy: 'Last Updated',
+      start: 0,
+      end: 3
+    }
+
+    const { getByTestId } = render(
+      <NewsReleases officeId={officeId} national={true} region={officeRegion} />
+    )
+    await waitForElement(() => getByTestId('news-cards'))
+
+    expect(fetchSiteContentStub).toHaveBeenCalledWith('articles', expectedQueryParams)
+  })
+  it('does NOT include officeId, national, or region query parameters in the fetch call when they do NOT exist as props', async () => {
+    fetchSiteContentStub.mockImplementationOnce(() => Promise.resolve(oneNewsReleaseData))
+
+    const expectedQueryParams = {
+      articleCategory: 'Press release',
+      sortBy: 'Last Updated',
+      start: 0,
+      end: 3
+    }
+
+    const { getByTestId } = render(<NewsReleases />)
+    await waitForElement(() => getByTestId('news-cards'))
+
+    expect(fetchSiteContentStub).toHaveBeenCalledWith('articles', expectedQueryParams)
   })
 })

--- a/test/jest/client/components/test-data/news-releases/oneNewsReleasesData.json
+++ b/test/jest/client/components/test-data/news-releases/oneNewsReleasesData.json
@@ -1,21 +1,24 @@
 {
   "items": [
     {
-      "articleId": {},
-      "category": [],
-      "mediaContact": {},
-      "office": 12345,
-      "officeLink": {},
-      "file": {},
-      "programs": [],
-      "summary": {},
-      "type": "article",
-      "title": "Test Article ",
-      "id": 19301,
-      "updated": 1563826928,
-      "created": 1563826909,
-      "langCode": "en",
-      "url": "/article/2019/jul/22/test-article"
+      "id": "20352",
+      "fields": {
+        "related_offices": ["15903", "15941", "15885", "6472", "6422"],
+        "updated": ["1574192812"],
+        "office": ["6453"],
+        "created": ["1574192626"],
+        "url": ["/article/2019/nov/19/cst-article-2-multiple-input-fields"],
+        "region": ["National (all regions)", "Region I", "Region V", "Region VI", "Region X"],
+        "title": ["CST Article 2 (multiple input fields)"],
+        "summary": ["summary and stuff"],
+        "article_category": [
+          "Congressional Testimony",
+          "Disaster Press Release",
+          "Media advisory",
+          "Policy notice"
+        ],
+        "article_programs": ["7(a)", "8(a)", "Agency Management", "CDC/504", "SBIC", "Surety Bonds"]
+      }
     }
   ],
   "count": 113

--- a/test/jest/client/components/test-data/news-releases/threeNewsReleasesData.json
+++ b/test/jest/client/components/test-data/news-releases/threeNewsReleasesData.json
@@ -1,58 +1,54 @@
 {
   "items": [
     {
-      "articleId": {},
-      "category": [],
-      "mediaContact": {},
-      "office": 12345,
-      "officeLink": {},
-      "file": {},
-      "programs": [],
-      "summary": {},
-      "type": "article",
-      "title": "Test Article ",
-      "id": 19301,
-      "updated": 1563826928,
-      "created": 1563826909,
-      "langCode": "en",
-      "url": "/article/2019/jul/22/test-article"
+      "id": "5250",
+      "fields": {
+        "related_offices": ["6422", "6472"],
+        "updated": ["1573579666"],
+        "office": ["7430"],
+        "created": ["1506878237"],
+        "url": ["/article/2017/oct/01/100-most-active-sba-7a-lenders"],
+        "title": ["100 most active SBA 7(a) lenders"],
+        "summary": [
+          "The table below displays the 100 most active SBA 7(a) lenders in the United States by lending volume through September 30, 2019. Results are updated quarterly."
+        ],
+        "article_programs": ["7(a)"]
+      }
     },
     {
-      "articleId": {},
-      "category": [],
-      "mediaContact": {},
-      "office": 12345,
-      "officeLink": {
-        "url": "/offices/headquarters/oca",
-        "title": "Office of Capital Access"
-      },
-      "file": {},
-      "programs": ["7(a)"],
-      "summary": "The table below displays the 100 most active SBA 7(a) lenders in the United States by lending volume through June 30, 2019. Results are updated quarterly.",
-      "type": "article",
-      "title": "100 most active SBA 7(a) lenders",
-      "id": 5250,
-      "updated": 1562772635,
-      "created": 1506878237,
-      "langCode": "en",
-      "url": "/article/2017/oct/01/100-most-active-sba-7a-lenders"
+      "id": "20351",
+      "fields": {
+        "related_offices": ["17054"],
+        "updated": ["1574192835"],
+        "office": ["6422"],
+        "created": ["1574192414"],
+        "url": ["/article/2019/nov/19/cst-article-2-single-input-fields"],
+        "region": ["National (all regions)"],
+        "title": ["CST Article 2 (single input fields)"],
+        "summary": ["summary text"],
+        "article_category": ["Press release"],
+        "article_programs": ["7(a)"]
+      }
     },
     {
-      "articleId": {},
-      "category": [],
-      "mediaContact": {},
-      "office": 12345,
-      "officeLink": {},
-      "file": {},
-      "programs": ["Contracting"],
-      "summary": "SBA Issues a Proposed Rule to Modify its Method for Calculating Annual Average Revenues",
-      "type": "article",
-      "title": "SBREA Online Notice",
-      "id": 19159,
-      "updated": 1561663856,
-      "created": 1561663619,
-      "langCode": "en",
-      "url": "/article/2019/jun/27/sbrea-online-notice"
+      "id": "20352",
+      "fields": {
+        "related_offices": ["15903", "15941", "15885", "6472", "6422"],
+        "updated": ["1574192812"],
+        "office": ["6453"],
+        "created": ["1574192626"],
+        "url": ["/article/2019/nov/19/cst-article-2-multiple-input-fields"],
+        "region": ["National (all regions)", "Region I", "Region V", "Region VI", "Region X"],
+        "title": ["CST Article 2 (multiple input fields)"],
+        "summary": ["summary and stuff"],
+        "article_category": [
+          "Congressional Testimony",
+          "Disaster Press Release",
+          "Media advisory",
+          "Policy notice"
+        ],
+        "article_programs": ["7(a)", "8(a)", "Agency Management", "CDC/504", "SBIC", "Surety Bonds"]
+      }
     }
   ],
   "count": 113


### PR DESCRIPTION
Can be observed here:
https://amy.ussba.io/offices/district/20353/ (no region specified for office)
https://amy.ussba.io/offices/district/20355/ (this office has a region that we will see in the article request)
Note that we will always see `national=true` in the query