### PR TITLE
TA-3350 change header to p tag; add styling; update snapshots

### DIFF
--- a/src/client/components/molecules/quick-links/quick-links.jsx
+++ b/src/client/components/molecules/quick-links/quick-links.jsx
@@ -156,9 +156,9 @@ const LatestDocumentsCard = props => {
   return (
     <div data-testid="documents-card" className={props.className}>
       <div className={styles.titleContainer}>
-        <h4 data-testid="header" className={styles.title}>
+        <p data-testid="header" className={styles.title}>
           {props.sectionHeaderText}
-        </h4>
+        </p>
         <Link
           data-testid="see-all-link"
           to={`/document?${queryString.stringify({
@@ -222,7 +222,7 @@ const LatestDocumentsCard = props => {
 const RatesCard = props => {
   return (
     <div className={props.className}>
-      <h4 className={styles.title}>Rates</h4>
+      <p className={styles.title}>Rates</p>
       <DecorativeDash width={30} />
       <div className={styles.list}>
         {props.rate.map((rate, index) => {
@@ -245,9 +245,9 @@ const ArticlesCard = props => {
   return (
     <div data-testid="articles-card" className={props.className}>
       <div className={styles.titleContainer}>
-        <h4 data-testid="header" className={styles.title}>
+        <p data-testid="header" className={styles.title}>
           {props.sectionHeaderText}
-        </h4>
+        </p>
         <Link
           data-testid="see-all-link"
           to={`/article?${queryString.stringify({

--- a/src/client/components/molecules/quick-links/quick-links.scss
+++ b/src/client/components/molecules/quick-links/quick-links.scss
@@ -50,6 +50,12 @@
 .title {
   display: inline-block;
   margin-bottom: 0;
+  margin-top: 0;
+  color: $sba-blue;
+  line-height: $heading-line-height;
+  font-weight: 600;
+  letter-spacing: -0.3px;
+  font-size: 1.23rem;
 }
 
 .date {

--- a/test/jest/client/components/molecules/quick-links/__snapshots__/quick-links.test.js.snap
+++ b/test/jest/client/components/molecules/quick-links/__snapshots__/quick-links.test.js.snap
@@ -12,12 +12,12 @@ exports[`QuickLinks snapshot tests Future effective date is not displayed 1`] = 
     <div
       className="titleContainer"
     >
-      <h4
+      <p
         className="title"
         data-testid="header"
       >
         SOPs
-      </h4>
+      </p>
       <a
         data-testid="see-all-link"
         onClick={[Function]}
@@ -62,12 +62,12 @@ exports[`QuickLinks snapshot tests Most recent effective date displayed 1`] = `
     <div
       className="titleContainer"
     >
-      <h4
+      <p
         className="title"
         data-testid="header"
       >
         SOPs
-      </h4>
+      </p>
       <a
         data-testid="see-all-link"
         onClick={[Function]}
@@ -112,12 +112,12 @@ exports[`QuickLinks snapshot tests No SOP number so it is not displayed 1`] = `
     <div
       className="titleContainer"
     >
-      <h4
+      <p
         className="title"
         data-testid="header"
       >
         SOPs
-      </h4>
+      </p>
       <a
         data-testid="see-all-link"
         onClick={[Function]}
@@ -162,12 +162,12 @@ exports[`QuickLinks snapshot tests SOP number exists and is displayed 1`] = `
     <div
       className="titleContainer"
     >
-      <h4
+      <p
         className="title"
         data-testid="header"
       >
         SOPs
-      </h4>
+      </p>
       <a
         data-testid="see-all-link"
         onClick={[Function]}


### PR DESCRIPTION
For the purposes of accessibility, the header of the quick links component has been changed to use a `p` tag instead of an `h4` and then added styling to make sure that the `p` tag displays the same.

Updated on Document List which can be seen at the bottom of the district office page:
https://amy.ussba.io/offices/district/6403/

Updated on Article List and Rates List which can be seen at the bottom of this page: http://localhost:3000/business-guide/plan-your-business/market-research-competitive-analysis