### PR TITLE
TA-3351 updated quick links to have aria label with see all link

### DIFF
--- a/src/client/components/molecules/quick-links/quick-links.jsx
+++ b/src/client/components/molecules/quick-links/quick-links.jsx
@@ -161,6 +161,7 @@ const LatestDocumentsCard = props => {
         </p>
         <Link
           data-testid="see-all-link"
+          aria-label="See all documents"
           to={`/document?${queryString.stringify({
             type: props.documentType,
             program: props.documentProgram,
@@ -250,6 +251,7 @@ const ArticlesCard = props => {
         </p>
         <Link
           data-testid="see-all-link"
+          aria-label="See all articles"
           to={`/article?${queryString.stringify({
             articleCategory: props.articleCategory,
             program: props.articleProgram

--- a/test/jest/client/components/molecules/quick-links/__snapshots__/quick-links.test.js.snap
+++ b/test/jest/client/components/molecules/quick-links/__snapshots__/quick-links.test.js.snap
@@ -19,6 +19,7 @@ exports[`QuickLinks snapshot tests Future effective date is not displayed 1`] = 
         SOPs
       </p>
       <a
+        aria-label="See all documents"
         data-testid="see-all-link"
         onClick={[Function]}
         style={Object {}}
@@ -69,6 +70,7 @@ exports[`QuickLinks snapshot tests Most recent effective date displayed 1`] = `
         SOPs
       </p>
       <a
+        aria-label="See all documents"
         data-testid="see-all-link"
         onClick={[Function]}
         style={Object {}}
@@ -119,6 +121,7 @@ exports[`QuickLinks snapshot tests No SOP number so it is not displayed 1`] = `
         SOPs
       </p>
       <a
+        aria-label="See all documents"
         data-testid="see-all-link"
         onClick={[Function]}
         style={Object {}}
@@ -169,6 +172,7 @@ exports[`QuickLinks snapshot tests SOP number exists and is displayed 1`] = `
         SOPs
       </p>
       <a
+        aria-label="See all documents"
         data-testid="see-all-link"
         onClick={[Function]}
         style={Object {}}


### PR DESCRIPTION
Deployed to https://pat.ussba.io/offices/district/6386/

Use screen reader to hear that "See All" button is labeled with "See all documents"