### PR TITLE
TA-3434 preserve order of authors on blogs landing page

### DIFF
--- a/src/client/components/pages/blogs-landing/blogs-landing.jsx
+++ b/src/client/components/pages/blogs-landing/blogs-landing.jsx
@@ -86,7 +86,7 @@ class BlogsLandingPage extends Component {
 
     if (nodeIds.length === authors.length) {
       // since map function returns promises from fetchSiteContent calls
-      // so we need to wait for all promises to resolve before setting the state
+      // we need to wait for all promises to resolve before setting the state
       authors = await Promise.all(authors)
       this.setState({ authors: compact(authors) })
     }

--- a/src/client/components/pages/blogs-landing/blogs-landing.jsx
+++ b/src/client/components/pages/blogs-landing/blogs-landing.jsx
@@ -76,15 +76,20 @@ class BlogsLandingPage extends Component {
   async fetchAuthors() {
     // fetch author ids from content search api
     // then fetch author objects from content node api by ids
-    const authors = []
     const nodeIds = await fetchSiteContent('authors')
-    nodeIds.forEach(async nodeId => {
-      const author = await fetchRestContent(nodeId)
-      authors.push(author)
-      if (nodeIds.length === authors.length) {
-        this.setState({ authors: compact(authors) })
-      }
+
+    // map function returns promises from fetchSiteContent calls
+    // but preserves order of nodeIds to authors in array
+    let authors = nodeIds.map(async nodeId => {
+      return await fetchRestContent(nodeId)
     })
+
+    if (nodeIds.length === authors.length) {
+      // since map function returns promises from fetchSiteContent calls
+      // so we need to wait for all promises to resolve before setting the state
+      authors = await Promise.all(authors)
+      this.setState({ authors: compact(authors) })
+    }
   }
 
   render() {


### PR DESCRIPTION
Updated on https://amy.ussba.io/blogs/

Authors should always display in the order the following order:
```
[18235,18210,7766,18220,18218,18219]

18235 Chris Pilkerton
18210 William Manger
7766 Larry Stubblefield
18220 Kathleen McShane
18218 Michele Schimpp
18219 Allen Gutierrez
```

Compare to https://mint.ussba.io/blogs/ where ordering of authors is not consistent.