### PR TITLE
TA-3314 created subpage navigation and unit tests

### DIFF
--- a/src/client/components/molecules/district-office-previous-next/district-office-previous-next.jsx
+++ b/src/client/components/molecules/district-office-previous-next/district-office-previous-next.jsx
@@ -1,0 +1,63 @@
+import React, { Component } from 'react'
+import previousNextSectionStyles from '../previous-next/previous-next.scss'
+
+const DistrictOfficePreviousNextSection = ({ data, currentPage, officeId, pageConnectorId }) => {
+  const previousArticle = ((pages, _currentPage) => {
+    let result
+    for (let i = 0; i < pages.length; i++) {
+      if (i > 0 && pages[i] === _currentPage) {
+        result = pages[i - 1]
+        break
+      }
+    }
+    return result
+  })(data, currentPage)
+
+  const nextArticle = ((pages, _currentPage) => {
+    let result
+    for (let i = 0; i < pages.length; i++) {
+      if (i < pages.length && pages[i] === _currentPage) {
+        result = pages[i + 1]
+        break
+      }
+    }
+    return result
+  })(data, currentPage)
+
+  return (
+    <div className={previousNextSectionStyles.previousNext} id="previous-next">
+      <div
+        className={`${previousNextSectionStyles.previous} ${!previousArticle &&
+          previousNextSectionStyles.invisible}`}
+      >
+        <h6>Previous</h6>
+        {previousArticle && (
+          <a
+            className={previousNextSectionStyles.button}
+            href={`/offices/district/${officeId}/${pageConnectorId}/${previousArticle.id}`}
+          >
+            <i className="fa fa-chevron-left" aria-hidden="true" />
+            <span>{previousArticle.title}</span>
+          </a>
+        )}
+      </div>
+      <div
+        className={`${previousNextSectionStyles.next} ${!nextArticle &&
+          previousNextSectionStyles.invisible}`}
+      >
+        <h6>Next</h6>
+        {nextArticle && (
+          <a
+            className={previousNextSectionStyles.button}
+            href={`/offices/district/${officeId}/${pageConnectorId}/${nextArticle.id}`}
+          >
+            <span>{nextArticle.title}</span>
+            <i className="fa fa-chevron-right" aria-hidden="true" />
+          </a>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default DistrictOfficePreviousNextSection

--- a/src/client/components/molecules/index.jsx
+++ b/src/client/components/molecules/index.jsx
@@ -8,6 +8,7 @@ import CardGrid from './card-grid/card-grid'
 import ContactCard from './contact-card/contact-card'
 import ContactCardLookup from './contact-card-lookup/contact-card-lookup'
 import DetailCard from './detail-card/detail-card'
+import DistrictOfficePreviousNextSection from './district-office-previous-next/district-office-previous-next'
 import FeedbackForm from './feedback-form/feedback-form'
 import FormPageButtons from './form-page-buttons/form-page-buttons'
 import GoogleTranslate from './google-translate/google-translate'
@@ -44,6 +45,7 @@ export {
   ContactCard,
   ContactCardLookup,
   DetailCard,
+  DistrictOfficePreviousNextSection,
   FeedbackForm,
   FormPageButtons,
   GoogleTranslate,

--- a/src/client/components/organisms/district-office-section-nav/district-office-section-nav.jsx
+++ b/src/client/components/organisms/district-office-section-nav/district-office-section-nav.jsx
@@ -1,0 +1,68 @@
+import React, { Component } from 'react'
+import Waypoint from 'react-waypoint'
+import sectionNavStyles from '../section-nav/section-nav.scss'
+import basicPageStyles from '../../templates/basic-page/basic-page.scss'
+
+const DistrictOfficeSectionNav = ({
+  officeId,
+  pageConnectorId,
+  subPageId,
+  title,
+  data,
+  position,
+  onTopEnter,
+  backLinkText
+}) => {
+  const stickyFunctionTop = () => {
+    return position === 'middle' ? sectionNavStyles.stickyTop : null
+  }
+  const stickyFunctionBottom = () => {
+    return position === 'bottom' ? sectionNavStyles.stickyBottom : null
+  }
+  const makeNavLinks = (_data, id) => {
+    const result = _data.map(function(item, index) {
+      const currentLinkClass = String(id) === String(item.id) ? sectionNavStyles.currentNavLink : ''
+      return (
+        <li className={currentLinkClass} key={index}>
+          <a
+            className="article-navigation-article-link-desktop"
+            id={'desktop-article-link-' + index}
+            href={`/offices/district/${officeId}/${pageConnectorId}/${item.id}`}
+          >
+            {item.title}
+          </a>
+        </li>
+      )
+    })
+    return result
+  }
+  const navLinks = makeNavLinks(data, subPageId)
+  return (
+    <div>
+      <div className={`basicpage-backlinkmobile ${basicPageStyles.backLinkMobile}`}>
+        <a id="backToallTopicsMobile" href={`/offices/district/${officeId}/`}>
+          {backLinkText}
+        </a>
+      </div>
+      <div
+        id="article-navigation-desktop"
+        className={sectionNavStyles.sectionNav + ' ' + stickyFunctionTop() + ' ' + stickyFunctionBottom()}
+      >
+        <Waypoint topOffset="30px" onEnter={onTopEnter} />
+        <a
+          id="article-navigation-back-button-desktop"
+          className={sectionNavStyles.backLink}
+          href={`/offices/district/${officeId}/`}
+        >
+          {backLinkText}
+        </a>
+        <span id="article-navigation-title-desktop">
+          <h3>{title}</h3>
+        </span>
+        <ul>{navLinks}</ul>
+      </div>
+    </div>
+  )
+}
+
+export default DistrictOfficeSectionNav

--- a/src/client/components/organisms/index.jsx
+++ b/src/client/components/organisms/index.jsx
@@ -7,6 +7,7 @@ import CoursesLayout from './courses-layout/courses-layout.jsx'
 import DefaultOfficeResult from './office-result/default-office-result.jsx'
 import DeveloperTester from './developer-tester/developer-tester.jsx'
 import DisasterAlert from './header-footer/disaster-alert/disaster-alert.jsx'
+import DistrictOfficeSectionNav from './district-office-section-nav/district-office-section-nav.jsx'
 import DocumentArticle from './document-article/document-article.jsx'
 import DocumentArticleLookup from './document-article-lookup/document-article-lookup.jsx'
 import DetailCardCollection from './detail-card-collection/detail-card-collection.jsx'
@@ -72,6 +73,7 @@ export {
   DefaultOfficeResult,
   DeveloperTester,
   DisasterAlert,
+  DistrictOfficeSectionNav,
   DocumentArticle,
   DocumentArticleLookup,
   DetailCardCollection,

--- a/src/client/components/routes.jsx
+++ b/src/client/components/routes.jsx
@@ -82,7 +82,10 @@ const DistrictOfficePage = props => (
 )
 
 const DistrictOfficeSubPageTemplate = props => (
-  <Async componentProps={props} load={import('./templates/district-office-subpage/district-office-subpage.jsx')} />
+  <Async
+    componentProps={props}
+    load={import('./templates/district-office-subpage/district-office-subpage.jsx')}
+  />
 )
 
 import { Route, IndexRoute, IndexRedirect, Redirect } from 'react-router'
@@ -122,8 +125,26 @@ const mainRoutes = [
   <Redirect key={69} from="/blogs/:category/:officeId" to="/blogs/:category/:officeId/" />,
   <Route key={70} path="/offices/district/:officeId/" component={DistrictOfficePage} />,
   <Redirect key={71} from="/offices/district/:officeId" to="/offices/district/:officeId/" />,
-  <Route key={72} path="/offices/district/:officeId/:subPageId/" component={DistrictOfficeSubPageTemplate} />,
-  <Redirect key={73} from="/offices/district/:officeId/:subPageId" to="/offices/district/:officeId/:subPageId/" />,
+  <Route
+    key={72}
+    path="/offices/district/:officeId/:pageConnectorId/"
+    component={DistrictOfficeSubPageTemplate}
+  />,
+  <Redirect
+    key={73}
+    from="/offices/district/:officeId/:pageConnectorId"
+    to="/offices/district/:officeId/:pageConnectorId/"
+  />,
+  <Route
+    key={74}
+    path="/offices/district/:officeId/:pageConnectorId/:subPageId"
+    component={DistrictOfficeSubPageTemplate}
+  />,
+  <Redirect
+    key={75}
+    from="/offices/district/:officeId/:pageConnectorId:/:subPageId"
+    to="/offices/district/:officeId/:pageConnectorId/:subPageId/"
+  />,
   <Route key={12} path="/business-guide/10-steps-start-your-business/" component={TenStepsLandingPage} />,
   <Route
     key={13}

--- a/src/client/components/templates/district-office-subpage/district-office-subpage.jsx
+++ b/src/client/components/templates/district-office-subpage/district-office-subpage.jsx
@@ -46,14 +46,14 @@ class DistrictOfficeSubPage extends Component {
           for (let i = 0; i < subpages.length; i++) {
             data.push(await fetchRestContent(subpages[i].id))
           }
-          this.setState({ title, data, loadingState: 'isLoaded' })
+          this.setState({ title, data, loadingState: 'isLoaded' }, () => {
+            listenForOverlap('#article-navigation-desktop', '#sba-footer', this.handleOverlap, {
+              listenOn: 'scroll'
+            })
+          })
         }
       )
     }
-
-    listenForOverlap('#article-navigation-desktop', '#sba-footer', this.handleOverlap, {
-      listenOn: 'scroll'
-    })
   }
   handleTopWaypointEnter() {
     this.setState({ currentPosition: 'top' })

--- a/src/client/components/templates/district-office-subpage/district-office-subpage.jsx
+++ b/src/client/components/templates/district-office-subpage/district-office-subpage.jsx
@@ -6,180 +6,228 @@ import { listenForOverlap } from 'element-overlap'
 import classNames from 'classnames'
 import { Loader } from 'atoms'
 import { TitleSection } from 'molecules'
-import { SectionNav } from 'organisms'
 import basicPageStyles from '../basic-page/basic-page.scss'
 import styles from './district-office-subpage.scss'
+import sectionNavStyles from '../../organisms/section-nav/section-nav.scss'
 import { fetchRestContent, fetchSiteContent } from '../../../fetch-content-helper.js'
 import * as paragraphMapper from '../paragraph-mapper.jsx'
 import { getLanguageOverride } from '../../../services/utils.js'
 
 class DistrictOfficeSubPage extends Component {
+  constructor() {
+    super()
+    this.state = {
+      sectionTitle: '',
+      data: {},
+      loadingState: 'unloaded',
+      slideLeftNavIn: false,
+      slideContentIn: false,
+      displayMobileNav: false,
+      currentPosition: 'top'
+    }
 
-	constructor() {
-	    super()
-	    this.state = {
-	      data: {},
-	      loadingState: 'unloaded',
-	      slideLeftNavIn: false,
-	      slideContentIn: false,
-	      displayMobileNav: false,
-	      currentPosition: 'top'
-	    }
+    this.handleSectionNavigationEnter = this.handleSectionNavigationEnter.bind(this)
+    this.handleTopWaypointEnter = this.handleTopWaypointEnter.bind(this)
+    this.handleTopWaypointLeave = this.handleTopWaypointLeave.bind(this)
+    this.handleBackLinkClicked = this.handleBackLinkClicked.bind(this)
+    this.handleOverlap = this.handleOverlap.bind(this)
+  }
+  async componentDidMount() {
+    const { pageConnectorId } = this.props.params
 
-	    this.handleSectionNavigationEnter = this.handleSectionNavigationEnter.bind(this)
-	    this.handleTopWaypointEnter = this.handleTopWaypointEnter.bind(this)
-	    this.handleTopWaypointLeave = this.handleTopWaypointLeave.bind(this)
-	    this.handleBackLinkClicked = this.handleBackLinkClicked.bind(this)
-	    this.handleOverlap = this.handleOverlap.bind(this)
-	}
+    if (pageConnectorId) {
+      this.setState(
+        {
+          loadingState: 'isLoading'
+        },
+        async () => {
+          const { title: sectionTitle, subpages } = await fetchRestContent(pageConnectorId)
+          const data = []
+          for (let i = 0; i < subpages.length; i++) {
+            data.push(await fetchRestContent(subpages[i].id))
+          }
+          this.setState({ sectionTitle, data, loadingState: 'isLoaded' })
+        }
+      )
+    }
 
-	async componentDidMount() {
-	    const { subPageId } = this.props.params
-	    if (subPageId) {
-	      this.setState(
-	        {
-	          loadingState: 'isLoading'
-	        },
-	        async () => {
-	          const data = await fetchRestContent(subPageId)
-	          this.setState({ data, loadingState: 'isLoaded' })
-	        }
-	      )
-	    }
+    listenForOverlap('#article-navigation-desktop', '#sba-footer', this.handleOverlap, {
+      listenOn: 'scroll'
+    })
+  }
+  handleBackLinkClicked(e) {
+    e.preventDefault()
+    this.setState({
+      slideLeftNavIn: false,
+      slideContentIn: false,
+      displayMobileNav: true
+    })
+  }
+  handleTopWaypointEnter() {
+    this.setState({ currentPosition: 'top' })
+  }
+  handleTopWaypointLeave() {
+    this.setState({ currentPosition: 'middle' })
+  }
+  handleBottomWaypointLeave() {
+    this.setState({ currentPosition: 'middle' })
+  }
+  handleSectionNavigationEnter() {
+    if (this.state.currentPosition === 'bottom') {
+      this.setState({ currentPosition: 'middle' })
+    }
+  }
+  handleOverlap() {
+    this.setState({ currentPosition: 'bottom' })
+  }
+  makeSectionHeaders(paragraphData) {
+    /* eslint-disable-next-line array-callback-return */
+    const sectionHeaders = paragraphData.map(function(item, index, paragraphArray) {
+      if (item && item.type && item.type === 'sectionHeader') {
+        return {
+          id: paragraphMapper.makeSectionHeaderId(index),
+          text: item.text
+        }
+      }
+    })
 
-	    /*listenForOverlap('#article-navigation-desktop', '#sba-footer', this.handleOverlap, {
-	      listenOn: 'scroll'
-	    })*/
-	}
+    return compact(sectionHeaders)
+  }
+  makeParagraphs(paragraphData) {
+    const paragraphList = paragraphMapper.makeParagraphs(paragraphData)
+    const wrapperClassMapping = {
+      other: basicPageStyles.textSection,
+      textSection: basicPageStyles.textSection,
+      textReadMoreSection: 'none',
+      sectionHeader: basicPageStyles.sectionHeader,
+      subsectionHeader: basicPageStyles.subsectionHeader,
+      image: basicPageStyles.image,
+      lookup: basicPageStyles.lookup,
+      callToAction: basicPageStyles.callToAction,
+      cardCollection: basicPageStyles.cardCollection,
+      styleGrayBackground: basicPageStyles.textSection
+    }
+    const wrapped = paragraphMapper.wrapParagraphs(paragraphList, wrapperClassMapping)
+    return wrapped
+  }
+  render() {
+    const { officeId, pageConnectorId, subPageId } = this.props.params
+    const { sectionTitle, data, loadingState, currentPosition, displayMobileNav } = this.state
+    let currentPage, className, langCode, paragraphs, sectionHeaders
 
-	makeSectionHeaders(paragraphData) {
-		/* eslint-disable-next-line array-callback-return */
-		const sectionHeaders = paragraphData.map(function(item, index, paragraphArray) {
-		  if (item && item.type && item.type === 'sectionHeader') {
-		    return {
-		      id: paragraphMapper.makeSectionHeaderId(index),
-		      text: item.text
-		    }
-		  }
-		})
+    if (!isEmpty(data)) {
+      currentPage = data.find(item => String(item.id) === subPageId) || data[0]
+      langCode = getLanguageOverride()
+      paragraphs = this.makeParagraphs(currentPage.paragraphs)
+      sectionHeaders = this.makeSectionHeaders(currentPage.paragraphs)
+      className = classNames({
+        'district-office-subpage-titlesection': true,
+        [styles.content]: true
+      })
+    }
 
-		return compact(sectionHeaders)
-	}
-
-	makeParagraphs(paragraphData) {
-		const paragraphList = paragraphMapper.makeParagraphs(paragraphData)
-		const wrapperClassMapping = {
-			other: basicPageStyles.textSection,
-			textSection: basicPageStyles.textSection,
-			textReadMoreSection: 'none',
-			sectionHeader: basicPageStyles.sectionHeader,
-			subsectionHeader: basicPageStyles.subsectionHeader,
-			image: basicPageStyles.image,
-			lookup: basicPageStyles.lookup,
-			callToAction: basicPageStyles.callToAction,
-			cardCollection: basicPageStyles.cardCollection,
-			styleGrayBackground: basicPageStyles.textSection
-		}
-		const wrapped = paragraphMapper.wrapParagraphs(paragraphList, wrapperClassMapping)
-		return wrapped
-	}
-
-	handleBackLinkClicked(e) {
-		e.preventDefault()
-		this.setState({
-		  slideLeftNavIn: false,
-		  slideContentIn: false,
-		  displayMobileNav: true
-		})
-	}
-
-	handleTopWaypointEnter() {
-		this.setState({ currentPosition: 'top' })
-	}
-
-	handleTopWaypointLeave() {
-		this.setState({ currentPosition: 'middle' })
-	}
-
-	handleBottomWaypointLeave() {
-		this.setState({ currentPosition: 'middle' })
-	}
-
-	handleSectionNavigationEnter() {
-		if (this.state.currentPosition === 'bottom') {
-		  this.setState({ currentPosition: 'middle' })
-		}
-	}
-
-	handleOverlap() {
-		this.setState({ currentPosition: 'bottom' })
-	}
-
-	sectionNavigation(langCode) {
-		return this.props.lineage ? (
-		  <SectionNav
-		    onTopEnter={this.handleSectionNavigationEnter}
-		    position={this.state.currentPosition}
-		    displayMobileNav={this.state.displayMobileNav}
-		    lineage={null}
-		    langCode={langCode}
-		  />
-		) : (
-		  <div />
-		)
-	}
-
-	render() {
-		const { data, loadingState } = this.state
-		let className, langCode, paragraphs, sectionHeaders
-
-		if (!isEmpty(data)) {
-			langCode = getLanguageOverride()
-			paragraphs = this.makeParagraphs(data.paragraphs)
-			sectionHeaders = this.makeSectionHeaders(data.paragraphs)
-			className = classNames({
-			    "district-office-subpage-titlesection": true,
-			    [styles.content]: true
-			})
-		}
-
-		return (
-			<div>
-				{loadingState === 'isLoading' && <div className={styles.loaderContainer}><Loader /></div>}
-				{loadingState === 'isLoaded' && (
-		          <div>
-		            {!isEmpty(data) ? (
-		            	<div>
-		            		<Waypoint
-					          topOffset="30px"
-					          onEnter={this.handleTopWaypointEnter}
-					          onLeave={this.handleTopWaypointLeave}
-					        />
-					        <div className="district-office-subpage-sectionnavigation">{this.sectionNavigation(langCode)}</div>
-		              		<div data-testid="district-office-subpage-titlesection" className={className}>
-								<TitleSection
-									key={1}
-									gridClass={basicPageStyles.titleSection}
-									sectionHeaders={sectionHeaders}
-									title={data.title}
-									summary={data.summary}
-								/>{' '}
-								{paragraphs}
-							</div>
-		            	</div>
-		            ) : (
-		              <div>No Data Found</div>
-		            )}
-		          </div>
-		        )}
-			</div>
-		)
-	}
+    return (
+      <div>
+        {loadingState === 'isLoading' && (
+          <div className={styles.loaderContainer}>
+            <Loader />
+          </div>
+        )}
+        {loadingState === 'isLoaded' && (
+          <div>
+            {!isEmpty(data) ? (
+              <div>
+                <Waypoint
+                  topOffset="30px"
+                  onEnter={this.handleTopWaypointEnter}
+                  onLeave={this.handleTopWaypointLeave}
+                />
+                <div
+                  data-testid="district-office-subpage-sectionnavigation"
+                  className="district-office-subpage-sectionnavigation"
+                >
+                  <SectionNav
+                    onTopEnter={this.handleSectionNavigationEnter}
+                    position={currentPosition}
+                    displayMobileNav={displayMobileNav}
+                    data={data}
+                    sectionTitle={sectionTitle}
+                    langCode={langCode}
+                    officeId={officeId}
+                    pageConnectorId={pageConnectorId}
+                    subPageId={!isEmpty(subPageId) ? subPageId : data[0].id}
+                  />
+                </div>
+                <div data-testid="district-office-subpage-titlesection" className={className}>
+                  <TitleSection
+                    key={1}
+                    gridClass={basicPageStyles.titleSection}
+                    sectionHeaders={sectionHeaders}
+                    title={currentPage.title}
+                    summary={currentPage.summary}
+                  />{' '}
+                  {paragraphs}
+                </div>
+              </div>
+            ) : (
+              <div>No Data Found</div>
+            )}
+          </div>
+        )}
+      </div>
+    )
+  }
 }
 
 DistrictOfficeSubPage.propTypes = {
   params: PropTypes.object,
   lineage: PropTypes.object
+}
+
+const SectionNav = ({ officeId, pageConnectorId, subPageId, sectionTitle, data, position, onTopEnter }) => {
+  const stickyFunctionTop = () => {
+    return position === 'middle' ? sectionNavStyles.stickyTop : null
+  }
+  const stickyFunctionBottom = () => {
+    return position === 'bottom' ? sectionNavStyles.stickyBottom : null
+  }
+  const makeNavLinks = (_data, id) => {
+    const result = _data.map(function(item, index) {
+      const currentLinkClass = String(id) === String(item.id) ? sectionNavStyles.currentNavLink : ''
+      return (
+        <li className={currentLinkClass} key={index}>
+          <a
+            className="article-navigation-article-link-desktop"
+            id={'desktop-article-link-' + index}
+            href={`/offices/district/${officeId}/${pageConnectorId}/${item.id}`}
+          >
+            {item.title}
+          </a>
+        </li>
+      )
+    })
+    return result
+  }
+  const navLinks = makeNavLinks(data, subPageId)
+  return (
+    <div
+      id="article-navigation-desktop"
+      className={sectionNavStyles.sectionNav + ' ' + stickyFunctionTop() + ' ' + stickyFunctionBottom()}
+    >
+      <Waypoint topOffset="30px" onEnter={onTopEnter} />
+      <a
+        id="article-navigation-back-button-desktop"
+        className={sectionNavStyles.backLink}
+        href={`/offices/district/${officeId}/`}
+      >
+        Back to District Office Main Page
+      </a>
+      <span id="article-navigation-title-desktop">
+        <h3>{sectionTitle}</h3>
+      </span>
+      <ul>{navLinks}</ul>
+    </div>
+  )
 }
 
 export default DistrictOfficeSubPage

--- a/src/client/components/templates/district-office-subpage/district-office-subpage.jsx
+++ b/src/client/components/templates/district-office-subpage/district-office-subpage.jsx
@@ -152,7 +152,6 @@ class DistrictOfficeSubPage extends Component {
                 </div>
                 <div data-testid="district-office-subpage-titlesection" className={className}>
                   <TitleSection
-                    key={1}
                     gridClass={basicPageStyles.titleSection}
                     sectionHeaders={sectionHeaders}
                     title={currentPage.title}

--- a/src/client/components/templates/district-office-subpage/district-office-subpage.jsx
+++ b/src/client/components/templates/district-office-subpage/district-office-subpage.jsx
@@ -220,7 +220,7 @@ const SectionNav = ({ officeId, pageConnectorId, subPageId, sectionTitle, data, 
         className={sectionNavStyles.backLink}
         href={`/offices/district/${officeId}/`}
       >
-        Back to District Office Main Page
+        Back to main page
       </a>
       <span id="article-navigation-title-desktop">
         <h3>{sectionTitle}</h3>

--- a/test/jest/client/components/templates/district-office-subpage/district-office-subpage.test.js
+++ b/test/jest/client/components/templates/district-office-subpage/district-office-subpage.test.js
@@ -1,54 +1,201 @@
 import React from 'react'
-import { render, cleanup, waitForElement, within } from 'react-testing-library'
+import { render, cleanup, waitForElement } from 'react-testing-library'
 import DistrictOfficeSubPageTemplate from 'templates/district-office-subpage/district-office-subpage.jsx'
 import { when, resetAllWhenMocks } from 'jest-when'
 import 'jest-dom/extend-expect'
 import * as fetchContentHelper from 'client/fetch-content-helper.js'
+import { Provider } from 'react-redux'
+import { createStore, applyMiddleware } from 'redux'
+import thunk from 'redux-thunk'
+import reducers from 'client/reducers'
 
+const mockSubPageData = [
+  {
+    paragraphs: [
+      {
+        id: 22889,
+        type: 'sectionheader',
+        text: 'about us'
+      },
+      {
+        id: 22890,
+        type: 'textsection',
+        text:
+          "<p>welcome to the 2019-2020 edition of the u.s. small business administration’s washington metropolitan area small business resource guide, covering the district of columbia, northern virginia and suburban maryland. with an increasingly diverse and well-educated workforce, the nation's capital and surrounding areas rank among the best locations to develop a successful small business. the sba helps make the american dream of small business ownership a reality. we are the only federal agency dedicated to helping our nation’s 30 million small businesses start, grow, expand, or recover after a disaster.</p>\r\n\r\n<p>over the past year, the sba washington metropolitan area district office has empowered small businesses to:</p>\r\n\r\n<ul>\r\n\t<li>find an ally or mentor via our network of sba-funded resource partners, which includes score, small business development centers, women’s business centers, and the veterans business outreach center.</li>\r\n\t<li>access over $335 million in sba-guaranteed loans through 52 local banks, credit unions, community-based lenders, and microlenders. these qualified borrowers hired over 4,900 new employees, bought needed equipment, and built or renovated facilities.</li>\r\n\t<li>gain more than $4.6 billion in federal contracting awards. the sba offers business development and technical support to nearly 1,000 local companies enrolled in the 8(a) business development program.</li>\r\n\t<li>our region is an innovation hub, home to more than 90,000 small businesses employing over 1 million people. the washington metro area generates a gdp of $530 billion annually, placing it among the 25 top producing countries. just as the american spirit of freedom and independence is deeply tied to our local history, so are we deeply committed to ensuring entrepreneurialism continues to strengthen the economy for everyone, now and into the future. stay informed about sba events near you and get valuable washington metro area business information by following us on twitter at @sba_dcmetro. register for email updates at sba.gov/updates.</li>\r\n</ul>\r\n"
+      }
+    ],
+    summary:
+      'welcome to the 2019-2020 edition of the u.s. small business administration’s washington metropolitan area small business resource guide.',
+    type: 'localresources',
+    title: 'washington metropolitan area resources',
+    id: 20242,
+    updated: 1572629482,
+    created: 1572629417,
+    langcode: 'en'
+  },
+  {
+    paragraphs: [
+      {
+        id: 22883,
+        type: 'sectionHeader',
+        text: 'The Startup Logistics'
+      },
+      {
+        id: 22884,
+        type: 'textSection',
+        text: '<p>www.google.com</p>\r\n\r\n<p>www.sba.gov</p>\r\n\r\n<p>www.bixal.com</p>\r\n'
+      }
+    ],
+    summary:
+      'Need to do research on your clients and location? View consumer and business data for your area using the Census Business Builder.',
+    type: 'localResources',
+    title: 'How to start a business in the Washington Metropolitan Area',
+    id: 20241,
+    updated: 1572629390,
+    created: 1572629291,
+    langCode: 'en'
+  },
+  {
+    paragraphs: [
+      {
+        id: 22877,
+        type: 'sectionHeader',
+        text: 'District of Columbia'
+      },
+      {
+        id: 22878,
+        type: 'textSection',
+        text: '<p>Bank of America</p>\r\n\r\n<p>Wells Fargo</p>\r\n\r\n<p>USAA</p>\r\n\r\n<p>Chase</p>\r\n'
+      }
+    ],
+    summary: 'The Washington area funding resources you need to know about.',
+    type: 'localResources',
+    title: 'Washington Metropolitan Area Funding Programs',
+    id: 20240,
+    updated: 1572629266,
+    created: 1572629128,
+    langCode: 'en'
+  }
+]
 
+const mockPageConnectorData = {
+  office: 6395,
+  subpages: [
+    {
+      id: 20242,
+      url: '/node/20242'
+    },
+    {
+      id: 20241,
+      url: '/node/20241'
+    },
+    {
+      id: 20240,
+      url: '/node/20240'
+    }
+  ],
+  type: 'pageConnector',
+  title: 'Washington Metropolitan Area B',
+  id: 20243,
+  updated: 1573247583,
+  created: 1572634173,
+  langCode: 'en',
+  url: '//washington-metropolitan-area-b'
+}
 
 afterEach(cleanup)
 
-const mockData = {
-    "paragraphs": [{
-            "id": 22889,
-            "type": "sectionHeader",
-            "text": "About us"
-        },
-        {
-            "id": 22890,
-            "type": "textSection",
-            "text": "<p>Welcome to the 2019-2020 edition of the U.S. Small Business Administration’s Washington Metropolitan Area Small Business Resource Guide, covering the District of Columbia, northern Virginia and suburban Maryland. With an increasingly diverse and well-educated workforce, the nation's capital and surrounding areas rank among the best locations to develop a successful small business. The SBA helps make the American dream of small business ownership a reality. We are the only federal agency dedicated to helping our nation’s 30 million small businesses start, grow, expand, or recover after a disaster.</p>\r\n\r\n<p>Over the past year, the SBA Washington Metropolitan Area District Office has empowered small businesses to:</p>\r\n\r\n<ul>\r\n\t<li>Find an ally or mentor via our network of SBA-funded Resource Partners, which includes SCORE, Small Business Development Centers, Women’s Business Centers, and the Veterans Business Outreach Center.</li>\r\n\t<li>Access over $335 million in SBA-guaranteed loans through 52 local banks, credit unions, community-based lenders, and microlenders. These qualified borrowers hired over 4,900 new employees, bought needed equipment, and built or renovated facilities.</li>\r\n\t<li>Gain more than $4.6 billion in federal contracting awards. The SBA offers business development and technical support to nearly 1,000 local companies enrolled in the 8(a) Business Development Program.</li>\r\n\t<li>Our region is an innovation hub, home to more than 90,000 small businesses employing over 1 million people. The Washington metro area generates a GDP of $530 billion annually, placing it among the 25 top producing countries. Just as the American spirit of freedom and independence is deeply tied to our local history, so are we deeply committed to ensuring entrepreneurialism continues to strengthen the economy for everyone, now and into the future. Stay informed about SBA events near you and get valuable Washington metro area business information by following us on Twitter at @sba_dcmetro. Register for email updates at sba.gov/updates.</li>\r\n</ul>\r\n"
-        }
-    ],
-    "summary": "Welcome to the 2019-2020 edition of the U.S. Small Business Administration’s Washington Metropolitan Area Small Business Resource Guide.",
-    "type": "localResources",
-    "title": "Washington Metropolitan Area Resources",
-    "id": 20242,
-    "updated": 1572629482,
-    "created": 1572629417,
-    "langCode": "en"
-}
-
 jest.mock('atoms/link/link.jsx', () => {
-	return {
-		__esModule: true,
-		default: () => <div />
-	}
+  return {
+    __esModule: true,
+    default: () => <div />
+  }
+})
+
+jest.mock('element-overlap', () => {
+  return {
+    listenForOverlap: () => {
+      return {
+        handleOverlap: () => false
+      }
+    }
+  }
 })
 
 describe('DistrictOfficeSubPageTemplate', () => {
-	it('should render content', async () => {
-		const params = {
-			subPageId: 20242
-		}
-		const fetchRestContentStub = jest.spyOn(fetchContentHelper, 'fetchRestContent')
-		when(fetchRestContentStub).calledWith(20242).mockImplementationOnce(() => {
-			return Promise.resolve(mockData)
-		})
+  let store
 
-    	const { getByTestId, getAllByTestId } = render(<DistrictOfficeSubPageTemplate params={params} />)
-	    let content = await waitForElement(() => getByTestId('district-office-subpage-titlesection'))
-	    expect(content).toBeInTheDocument()
-	})
+  beforeAll(() => {
+    const initialState = undefined
+    const enhancer = applyMiddleware(thunk)
+    store = createStore(reducers, initialState, enhancer)
+  })
+  it('should render content', async () => {
+    const params = {
+      pageConnectorId: 20243
+    }
+
+    const fetchRestContentStub = jest.spyOn(fetchContentHelper, 'fetchRestContent')
+    when(fetchRestContentStub)
+      .calledWith(20243)
+      .mockImplementationOnce(() => {
+        return Promise.resolve(mockPageConnectorData)
+      })
+    when(fetchRestContentStub)
+      .calledWith(20242)
+      .mockImplementationOnce(() => {
+        return Promise.resolve(mockSubPageData[0])
+      })
+    when(fetchRestContentStub)
+      .calledWith(20241)
+      .mockImplementationOnce(() => {
+        return Promise.resolve(mockSubPageData[1])
+      })
+    when(fetchRestContentStub)
+      .calledWith(20240)
+      .mockImplementationOnce(() => {
+        return Promise.resolve(mockSubPageData[2])
+      })
+    const { getByTestId, getAllByTestId } = render(
+      <Provider store={store}>
+        <DistrictOfficeSubPageTemplate params={params} />
+      </Provider>
+    )
+    const content = await waitForElement(() => getByTestId('district-office-subpage-titlesection'))
+    expect(content).toBeInTheDocument()
+  })
+  it('should render side navigation', async () => {
+    const params = {
+      pageConnectorId: 20243
+    }
+
+    const fetchRestContentStub = jest.spyOn(fetchContentHelper, 'fetchRestContent')
+    when(fetchRestContentStub)
+      .calledWith(20243)
+      .mockImplementationOnce(() => {
+        return Promise.resolve(mockPageConnectorData)
+      })
+    when(fetchRestContentStub)
+      .calledWith(20242)
+      .mockImplementationOnce(() => {
+        return Promise.resolve(mockSubPageData[0])
+      })
+    when(fetchRestContentStub)
+      .calledWith(20241)
+      .mockImplementationOnce(() => {
+        return Promise.resolve(mockSubPageData[1])
+      })
+    when(fetchRestContentStub)
+      .calledWith(20240)
+      .mockImplementationOnce(() => {
+        return Promise.resolve(mockSubPageData[2])
+      })
+    const { getByTestId, getAllByTestId } = render(
+      <Provider store={store}>
+        <DistrictOfficeSubPageTemplate params={params} />
+      </Provider>
+    )
+    const content = await waitForElement(() => getByTestId('district-office-subpage-sectionnavigation'))
+    expect(content).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
for jira ticket https://us-sba.atlassian.net/browse/TA-3314

- [x] Use existing 'section nav' component for left navigation
- [x] The links under the left nav will display based on the subpage titles entered by the user in D8
- [x] Replace “Launch your business” with “District office of [city]” (whatever the District office name is)
- [x] Remove (do not include) breadcrumbs from this page
To Do:
- [x] Replace “Back to all topics” with “Back to main page”
- [x] format for mobile

To Test, visit:
https://avery.ussba.io/offices/district/6386/20243