### PR TITLE
Feature ta 3519

### DIFF
--- a/src/client/components/pages/sitemap-page/sitemap-page.jsx
+++ b/src/client/components/pages/sitemap-page/sitemap-page.jsx
@@ -41,7 +41,12 @@ class SiteMapPage extends Component {
     }
 
     const linkTree = renderLinkList(siteMap)
-    return <div>{linkTree}</div>
+    return (
+      <div data-testid="sitemap" className={styles.container}>
+        <h1>Site Map</h1>
+        {linkTree}
+      </div>
+    )
   }
 }
 

--- a/src/client/components/pages/sitemap-page/sitemap-page.jsx
+++ b/src/client/components/pages/sitemap-page/sitemap-page.jsx
@@ -1,0 +1,48 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import { isEmpty } from 'lodash'
+
+import { fetchRestContent } from '../../../fetch-content-helper'
+import styles from './sitemap-page.scss'
+
+class SiteMapPage extends Component {
+  constructor() {
+    super()
+    this.state = {
+      siteMap: []
+    }
+  }
+
+  async componentDidMount() {
+    const pathname = this.props.location.pathname
+    const siteMap = await fetchRestContent('siteMap')
+
+    if (!isEmpty(siteMap)) {
+      this.setState({ siteMap })
+    }
+  }
+
+  render() {
+    const { siteMap } = this.state
+
+    const renderLinkList = items => {
+      return (
+        <ul className={styles.linkList}>
+          {items.map(item => {
+            return (
+              <li>
+                <a href={item.fullUrl}>{item.title}</a>
+                {item.children && renderLinkList(item.children)}
+              </li>
+            )
+          })}
+        </ul>
+      )
+    }
+
+    const linkTree = renderLinkList(siteMap)
+    return <div>{linkTree}</div>
+  }
+}
+
+export default SiteMapPage

--- a/src/client/components/pages/sitemap-page/sitemap-page.scss
+++ b/src/client/components/pages/sitemap-page/sitemap-page.scss
@@ -1,0 +1,3 @@
+.linkList {
+	margin-left: 50px;
+}

--- a/src/client/components/pages/sitemap-page/sitemap-page.scss
+++ b/src/client/components/pages/sitemap-page/sitemap-page.scss
@@ -1,3 +1,22 @@
+.container {
+  word-break: break-word;
+  padding: 30px 30px 0 30px;
+
+  h1 {
+    font-size: 28px;
+    font-weight: 400;
+    margin-bottom: 0;
+
+    @include for-large-up {
+      font-size: 36px;
+    }
+  }
+
+  @include for-medium-up {
+    width: 700px;
+    margin: 0 auto;
+  }
+}
 .linkList {
 	margin-left: 50px;
 }

--- a/src/client/components/routes.jsx
+++ b/src/client/components/routes.jsx
@@ -88,6 +88,10 @@ const DistrictOfficeSubPageTemplate = props => (
   />
 )
 
+const SiteMapPage = props => (
+  <Async componentProps={props} load={import('./pages/sitemap-page/sitemap-page.jsx')} />
+)
+
 import { Route, IndexRoute, IndexRedirect, Redirect } from 'react-router'
 import constants from '../services/constants.js'
 import clientConfig from '../services/client-config.js'
@@ -146,6 +150,8 @@ const mainRoutes = [
     from="/offices/district/:officeId/:pageConnectorId:/:subPageId"
     to="/offices/district/:officeId/:pageConnectorId/:subPageId/"
   />,
+  <Route key={76} path="/sitemap" component={SiteMapPage} />,
+  <Redirect key={77} from="/sitemap/" to="/sitemap" />,
   <Route key={12} path="/business-guide/10-steps-start-your-business/" component={TenStepsLandingPage} />,
   <Route
     key={13}

--- a/test/jest/client/components/pages/sitemap-page/sitemap-page.test.js
+++ b/test/jest/client/components/pages/sitemap-page/sitemap-page.test.js
@@ -4,7 +4,7 @@ import 'jest-dom/extend-expect'
 import * as helpers from 'client/fetch-content-helper'
 import SiteMapPage from 'client/components/pages/sitemap-page/sitemap-page'
 
-describe.only('SiteMap', () => {
+describe('SiteMap', () => {
   it('fetches siteMap.json data', () => {
     helpers.fetchRestContent = jest.fn().mockImplementationOnce(() => Promise.resolve())
     const { getByTestId } = render(<SiteMapPage />)

--- a/test/jest/client/components/pages/sitemap-page/sitemap-page.test.js
+++ b/test/jest/client/components/pages/sitemap-page/sitemap-page.test.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import { render, cleanup, waitForElement } from 'react-testing-library'
+
+import * as clientConfig from 'client/services/client-config'
+import * as helpers from 'client/fetch-content-helper'
+import SiteMapPage from 'client/components/pages/sitemap-page/sitemap-page'
+
+describe.only('SiteMap', () => {
+  it('fetches siteMap.json data', () => {
+    clientConfig.getConfig = jest.fn().mockImplementation(_ => 404)
+    helpers.fetchRestContent = jest.fn().mockImplementation(() => Promise.resolve())
+    const { getByTestId } = render(<SiteMapPage />)
+    //expect(getByTestId('blogs-hero')).toBeInTheDocument()
+  })
+})

--- a/test/jest/client/components/pages/sitemap-page/sitemap-page.test.js
+++ b/test/jest/client/components/pages/sitemap-page/sitemap-page.test.js
@@ -1,15 +1,13 @@
 import React from 'react'
 import { render, cleanup, waitForElement } from 'react-testing-library'
-
-import * as clientConfig from 'client/services/client-config'
+import 'jest-dom/extend-expect'
 import * as helpers from 'client/fetch-content-helper'
 import SiteMapPage from 'client/components/pages/sitemap-page/sitemap-page'
 
 describe.only('SiteMap', () => {
   it('fetches siteMap.json data', () => {
-    clientConfig.getConfig = jest.fn().mockImplementation(_ => 404)
-    helpers.fetchRestContent = jest.fn().mockImplementation(() => Promise.resolve())
+    helpers.fetchRestContent = jest.fn().mockImplementationOnce(() => Promise.resolve())
     const { getByTestId } = render(<SiteMapPage />)
-    //expect(getByTestId('blogs-hero')).toBeInTheDocument()
+    expect(getByTestId('sitemap')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
for jira ticket https://us-sba.atlassian.net/browse/TA-3519

Page is created in Katana to display sitemap list with URL links

- [x] new component created
- [x] routing to the component is set up
- [x] NGINX redirects /sitemap to Katana (done in https://github.com/USSBA/sba-gov-infrastructure/pull/391)
- [x] Footer link on SBA.gov's sitemap re-directs from the D7 version to D8 version of the sitemap
- [x] D8 version of sitemap is accessible 