### PR TITLE
Feature ta 3614

### DIFF
--- a/config/avery.yml
+++ b/config/avery.yml
@@ -23,4 +23,4 @@ features:
         tableName: UrlToUrlRedirectAvery
 content:
     cloudfront: d8ptg6c733nbj.cloudfront.net
-    useD8EventsBackend: true
+    useD8EventsBackend: false

--- a/src/client/components/pages/event-page/event-page.jsx
+++ b/src/client/components/pages/event-page/event-page.jsx
@@ -36,8 +36,13 @@ class EventPage extends Component {
     return (
       <div>
         {!eventId && <ErrorPage linkUrl="/events/find" linkMessage="find events page" />}
-        {eventId && LOADING_STATE === 'loaded' && (!isEmpty(data) ? <div><Event eventData={data} /></div> : <ErrorPage linkUrl="/events/find" linkMessage="find events page" />)}
-        {eventId && LOADING_STATE !== 'loaded' && <div className={styles.container}><Loader /></div>}
+        {eventId && <div>
+          {LOADING_STATE !== 'loaded' && <div className={styles.container}><Loader /></div>}
+          {LOADING_STATE === 'loaded' && <div>
+            {isEmpty(data) && <ErrorPage linkUrl="/events/find" linkMessage="find events page" />}
+            {!isEmpty(data) && <Event eventData={data} />}
+          </div>}
+        </div>}
       </div>
     )
   }

--- a/src/client/components/pages/event-page/event-page.jsx
+++ b/src/client/components/pages/event-page/event-page.jsx
@@ -20,12 +20,11 @@ class EventPage extends Component {
     const queryArgs = {
       id: String(this.props.params.eventId)
     }
-    let result
     const results = await fetchSiteContent('events', queryArgs).catch( _ => {
       this.setState({ data: null })
     })
     // TODO: remove feature flag after updating events backend
-    result = clientConfig.useD8EventsBackend ? results.hit : results.items
+    const result = clientConfig.useD8EventsBackend ? results.hit : results.items
     const data = !isEmpty(result) ? result[0] : null
     this.setState({ data, LOADING_STATE: 'loaded' })
   }

--- a/src/client/components/pages/event-page/event-page.jsx
+++ b/src/client/components/pages/event-page/event-page.jsx
@@ -11,49 +11,36 @@ import clientConfig from '../../../services/client-config.js'
 class EventPage extends Component {
   constructor() {
     super()
-    this.state = {}
+    this.state = {
+      LOADING_STATE: 'unloaded'
+    }
   }
 
   async componentDidMount() {
     const queryArgs = {
       id: String(this.props.params.eventId)
     }
+    let result
+    const results = await fetchSiteContent('events', queryArgs).catch( _ => {
+      this.setState({ data: null })
+    })
     // TODO: remove feature flag after updating events backend
-    if (clientConfig.useD8EventsBackend) {
-      const { hit } = await fetchSiteContent('events', queryArgs).catch(_ => this.setState({ data: null }))
-      if (hit && hit[0]) {
-        this.setState({ data: hit[0] })
-      }
-    } else {
-      const { items } = await fetchSiteContent('events', queryArgs).catch(_ =>
-        this.setState({ data: null })
-      )
-      if (items && items[0]) {
-        this.setState({ data: items[0] })
-      }
-    }
+    result = clientConfig.useD8EventsBackend ? results.hit : results.items
+    const data = !isEmpty(result) ? result[0] : null
+    this.setState({ data, LOADING_STATE: 'loaded' })
   }
 
   render() {
     const { eventId } = this.props.params
-    const { data } = this.state
-    if (eventId && data) {
-      if (!isEmpty(data)) {
-        return (
-          <div>
-            <Event eventData={data} />
-          </div>
-        )
-      } else {
-        return <ErrorPage linkUrl="/events/find" linkMessage="find events page" />
-      }
-    } else {
-      return (
-        <div className={styles.container}>
-          <Loader />
-        </div>
-      )
-    }
+    const { data, LOADING_STATE } = this.state
+
+    return (
+      <div>
+        {!eventId && <ErrorPage linkUrl="/events/find" linkMessage="find events page" />}
+        {eventId && LOADING_STATE === 'loaded' && (!isEmpty(data) ? <div><Event eventData={data} /></div> : <ErrorPage linkUrl="/events/find" linkMessage="find events page" />)}
+        {eventId && LOADING_STATE !== 'loaded' && <div className={styles.container}><Loader /></div>}
+      </div>
+    )
   }
 }
 

--- a/test/jest/client/components/pages/event-page/event-page.test.jsx
+++ b/test/jest/client/components/pages/event-page/event-page.test.jsx
@@ -41,7 +41,7 @@ describe('Event Page', () => {
       }
     }
     const component = shallow(<EventPage {...props} />)
-    component.setState({ data: {} })
+    component.setState({ data: {}, LOADING_STATE: 'loaded' })
     const result = component.find('ErrorPage')
     const expected = 1
     expect(result).toHaveLength(expected)
@@ -50,11 +50,11 @@ describe('Event Page', () => {
   test('should render the event component when event data is set', () => {
     const props = {
       params: {
-        eventId: "304"
+        eventId: "304",
       }
     }
     const component = shallow(<EventPage {...props} />)
-    component.setState({ data: { title: 'foo' } })
+    component.setState({ data: { title: 'foo' }, LOADING_STATE: 'loaded' })
     const result = component.find('Event')
     const expected = 1
     expect(result).toHaveLength(expected)


### PR DESCRIPTION
for jira ticket https://us-sba.atlassian.net/browse/TA-3614

AC:
- [x] The D7 Event detail page is fixed

Before, now matter what event was clicked on, only the most recent event detail information displayed.

Now, any event that is clicked on from https://avery.ussba.io/events/ will open to its correct event detail information.