### PR TITLE
TC-3 added website to lender details and contact card components

### DIFF
--- a/src/client/components/molecules/contact-card/contact-card.jsx
+++ b/src/client/components/molecules/contact-card/contact-card.jsx
@@ -15,11 +15,11 @@ const formatHours = hoursOfOperation => {
 }
 
 const formatWebsite = website => {
-  let link
+  let linkText
   if (website && website.length > 0) {
-    link = 'Website'
+    linkText = 'Vist Website'
   }
-  return link
+  return linkText
 }
 
 // TODO: The link card component has overlapping functionality and should be
@@ -101,7 +101,8 @@ const ContactCard = props => {
       name: 'website',
       text: formatWebsite(website),
       href: website,
-      ariaLabel: 'link icon'
+      icon: 'external-link-square',
+      ariaLabel: 'website icon'
     },
     {
       name: 'hours of operation',

--- a/src/client/components/molecules/contact-card/contact-card.jsx
+++ b/src/client/components/molecules/contact-card/contact-card.jsx
@@ -14,14 +14,6 @@ const formatHours = hoursOfOperation => {
   return hours
 }
 
-const formatWebsite = website => {
-  let linkText
-  if (website && website.length > 0) {
-    linkText = 'Vist Website'
-  }
-  return linkText
-}
-
 // TODO: The link card component has overlapping functionality and should be
 // combined with the contact card.
 const ContactCard = props => {
@@ -39,7 +31,6 @@ const ContactCard = props => {
     state,
     streetAddress,
     title,
-    website,
     zipCode,
     className: cn,
     testId
@@ -96,13 +87,6 @@ const ContactCard = props => {
       icon: 'envelope-o',
       href: `mailto:${email}`,
       ariaLabel: 'email icon'
-    },
-    {
-      name: 'website',
-      text: formatWebsite(website),
-      href: website,
-      icon: 'external-link-square',
-      ariaLabel: 'website icon'
     },
     {
       name: 'hours of operation',

--- a/src/client/components/molecules/contact-card/contact-card.jsx
+++ b/src/client/components/molecules/contact-card/contact-card.jsx
@@ -14,6 +14,14 @@ const formatHours = hoursOfOperation => {
   return hours
 }
 
+const formatWebsite = website => {
+  let link
+  if (website && website.length > 0) {
+    link = 'Website'
+  }
+  return link
+}
+
 // TODO: The link card component has overlapping functionality and should be
 // combined with the contact card.
 const ContactCard = props => {
@@ -31,6 +39,7 @@ const ContactCard = props => {
     state,
     streetAddress,
     title,
+    website,
     zipCode,
     className: cn,
     testId
@@ -87,6 +96,12 @@ const ContactCard = props => {
       icon: 'envelope-o',
       href: `mailto:${email}`,
       ariaLabel: 'email icon'
+    },
+    {
+      name: 'website',
+      text: formatWebsite(website),
+      href: website,
+      ariaLabel: 'link icon'
     },
     {
       name: 'hours of operation',
@@ -166,6 +181,7 @@ ContactCard.propTypes = {
   state: PropTypes.string,
   streetAddress: PropTypes.string,
   title: PropTypes.string,
+  website: PropTypes.string,
   zipCode: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   testId: PropTypes.string
 }

--- a/src/client/components/molecules/contact-card/contact-card.jsx
+++ b/src/client/components/molecules/contact-card/contact-card.jsx
@@ -166,7 +166,6 @@ ContactCard.propTypes = {
   state: PropTypes.string,
   streetAddress: PropTypes.string,
   title: PropTypes.string,
-  website: PropTypes.string,
   zipCode: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   testId: PropTypes.string
 }

--- a/src/client/components/organisms/lender-detail/lender-detail.jsx
+++ b/src/client/components/organisms/lender-detail/lender-detail.jsx
@@ -46,6 +46,7 @@ class LenderDetail extends React.PureComponent {
       email: '',
       phoneNumber: item.bank_phone ? item.bank_phone[0] : '',
       fax: item.contact_fax ? item.contact_fax[0] : '',
+      website: item.website ? item.website[0] : '',
       border: false
     }
 

--- a/src/client/components/organisms/lender-detail/lender-detail.jsx
+++ b/src/client/components/organisms/lender-detail/lender-detail.jsx
@@ -46,7 +46,7 @@ class LenderDetail extends React.PureComponent {
       email: '',
       phoneNumber: item.bank_phone ? item.bank_phone[0] : '',
       fax: item.contact_fax ? item.contact_fax[0] : '',
-      website: item.website ? item.website[0] : '',
+      link: item.website ? item.website[0] : '',
       border: false
     }
 

--- a/src/client/components/pages/lender-lookup-page/lender-lookup-page.jsx
+++ b/src/client/components/pages/lender-lookup-page/lender-lookup-page.jsx
@@ -54,7 +54,6 @@ class LenderLookupPage extends React.PureComponent {
 
   render() {
     const { selectedItem, newCenter, shouldCenterMap, hoveredMarkerId } = this.state
-    const showTaxQuestion = false
     const pageSize = 5
     const defaultSearchParams = {
       pageSize

--- a/src/client/components/pages/lender-lookup-page/lender-lookup-page.jsx
+++ b/src/client/components/pages/lender-lookup-page/lender-lookup-page.jsx
@@ -54,6 +54,7 @@ class LenderLookupPage extends React.PureComponent {
 
   render() {
     const { selectedItem, newCenter, shouldCenterMap, hoveredMarkerId } = this.state
+    const showTaxQuestion = false
     const pageSize = 5
     const defaultSearchParams = {
       pageSize
@@ -93,7 +94,8 @@ class LenderLookupPage extends React.PureComponent {
             }}
             errorText="Enter a 5-digit zip code."
           />
-          <MultiSelect
+          {/* TC-3 Uncomment when adding back in tax question */}
+          {/* <MultiSelect
             id="has-filed-2019-taxes"
             queryParamName="hasFiled2019Taxes"
             label="Have you filed your 2019 Taxes?"
@@ -111,7 +113,7 @@ class LenderLookupPage extends React.PureComponent {
               }
             ]}
             dataCy="has-filed-2019-taxes"
-          />
+          /> */}
         </PrimarySearchBar>
         <OfficeMap
           id="office-map"

--- a/test/jest/client/components/pages/lender-lookup-page/lender-lookup-page.test.jsx
+++ b/test/jest/client/components/pages/lender-lookup-page/lender-lookup-page.test.jsx
@@ -7,7 +7,8 @@ import { MultiSelect } from 'atoms'
 import moment from 'moment'
 
 describe('LenderLookupPage', () => {
-  it('should selct the rapid lenders dropdown', () => {
+  // TC-3 skipping test until we add back in tax question for find lender ppp page
+  it.skip('should selct the rapid lenders dropdown', () => {
     const component = mount(<LenderLookupPage />)
     const result = component.find('[data-cy="has-filed-2019-taxes"]')
     expect(result).toHaveLength(1)


### PR DESCRIPTION
This is to display website information in the contact card on the ppp lender map.
To see in action go to `https://pat.ussba.io/paycheckprotection/find?address=48342&hasFiled2019Taxes=true&pageNumber=1` and select the second result `Bank of America Financial Center`. You should see a link at the bottom of the lender details card that says "Website". Clicking on that should take you to the bank of america webpage. Other lenders should not have website information as of 2:30 on 4/10