### PR TITLE
TA-3617 fixed events pagination to use count value

### DIFF
--- a/src/client/components/pages/event-lookup-page/event-lookup-page.jsx
+++ b/src/client/components/pages/event-lookup-page/event-lookup-page.jsx
@@ -96,8 +96,7 @@ class EventLookupPage extends React.PureComponent {
       if (searchResults) {
         // TODO: remove feature flag when updated events backend launches
         results = clientConfig.useD8EventsBackend ? searchResults.hit : searchResults.items
-        // results = searchResults.hit
-        count = searchResults.found
+        count = searchResults.count
         hasNoResults = count === 0
         isLoading = false
         isZeroState = false

--- a/src/client/components/pages/event-lookup-page/event-lookup-page.jsx
+++ b/src/client/components/pages/event-lookup-page/event-lookup-page.jsx
@@ -96,7 +96,7 @@ class EventLookupPage extends React.PureComponent {
       if (searchResults) {
         // TODO: remove feature flag when updated events backend launches
         results = clientConfig.useD8EventsBackend ? searchResults.hit : searchResults.items
-        count = searchResults.count
+        count = clientConfig.useD8EventsBackend ? searchResults.found : searchResults.count
         hasNoResults = count === 0
         isLoading = false
         isZeroState = false


### PR DESCRIPTION
Deployed to [https://pat.ussba.io/events/find](https://pat.ussba.io/events/find)
Verify that the number of results is displayed at the top of the page and the pagination displays correctly at the bottom of the page