### PR TITLE
TC-39: Display District Office info for users to report incorrect map information.

### DIFF
--- a/src/client/components/pages/lender-lookup-page/lender-lookup-page.jsx
+++ b/src/client/components/pages/lender-lookup-page/lender-lookup-page.jsx
@@ -155,6 +155,10 @@ class LenderLookupPage extends React.PureComponent {
             <LenderResult />
           </Results>
         </StyleWrapperDiv>
+        <div className={styles.noticeWithLink}>
+          {`If you notice incorrect bank information, please contact your `}
+          <a href="https://www.sba.gov/tools/local-assistance/districtoffices">SBA District Office</a>
+        </div>
       </SearchTemplate>
     )
   }

--- a/src/client/components/pages/lender-lookup-page/lender-lookup-page.scss
+++ b/src/client/components/pages/lender-lookup-page/lender-lookup-page.scss
@@ -86,6 +86,18 @@
   }
 }
 
+.noticeWithLink {
+  background-color: $secondary-blue-dark;
+  color: $sba-blue-lighter;
+  padding: $small-spacing;
+  font-family: $serif-font-family;
+  font-style: italic;
+
+  a {
+    color: inherit;
+  }
+}
+
 .multiselect {
   label {
     font-weight: 400;

--- a/test/jest/client/components/pages/lender-lookup-page/lender-lookup-page.test.jsx
+++ b/test/jest/client/components/pages/lender-lookup-page/lender-lookup-page.test.jsx
@@ -38,6 +38,14 @@ describe('LenderLookupPage', () => {
       const wrapper = shallow(<LenderLookupPage />)
       expect(wrapper.find('Results')).toHaveLength(1)
     })
+
+    it('renders a notice with link to SBA District Office', () => {
+      const wrapper = shallow(<LenderLookupPage />)
+      expect(wrapper.find('.noticeWithLink')).toHaveLength(1)
+      expect(
+        wrapper.find('[href="https://www.sba.gov/tools/local-assistance/districtoffices"]')
+      ).toHaveLength(1)
+    })
   })
 
   describe('actions', () => {


### PR DESCRIPTION
Add link to SBA District Office to the bottom of the map on lender lookup page.

Add tests to assert the presence of the right link

![Screen Shot 2020-04-25 at 1 54 53 PM](https://user-images.githubusercontent.com/12025195/80287222-52f7ad00-86fe-11ea-92b9-88381446889d.png)
