### PR TITLE
Lender results card UI changes

### DIFF
--- a/src/client/components/molecules/contact-card/contact-card.jsx
+++ b/src/client/components/molecules/contact-card/contact-card.jsx
@@ -77,7 +77,7 @@ const ContactCard = props => {
     {
       name: 'contact link',
       text: linkText,
-      icon: 'external-link-square',
+      icon: 'globe',
       href: link,
       ariaLabel: 'website icon'
     },

--- a/src/client/components/organisms/lender-detail/lender-detail.jsx
+++ b/src/client/components/organisms/lender-detail/lender-detail.jsx
@@ -1,9 +1,6 @@
 import React from 'react'
 import classNames from 'classnames'
-import marker from 'assets/svg/marker.svg'
-import exitIcon from 'assets/svg/icons/close-icon-sm-blue.svg'
 import styles from './lender-detail.scss'
-import lenderResultStyles from '../lender-result/lender-result.scss'
 import { ContactCard } from 'molecules'
 
 class LenderDetail extends React.PureComponent {
@@ -28,69 +25,39 @@ class LenderDetail extends React.PureComponent {
   }
 
   render() {
-    const { selectedItem, hideDetailState } = this.props
-    const { item, distance } = selectedItem
+    const {
+      item: { fields }
+    } = this.props
 
-    const address1 = item.address ? item.address[0] : ''
-    const address2 = item.address_additional ? item.address_additional[0] : ''
-    const firstName = item.contact_first_name ? item.contact_first_name[0] : ''
-    const lastName = item.contact_last_name ? item.contact_last_name[0] : ''
+    const address1 = fields.address ? fields.address[0] : ''
+    const address2 = fields.address_additional ? fields.address_additional[0] : ''
+    const firstName = fields.contact_first_name ? fields.contact_first_name[0] : ''
+    const lastName = fields.contact_last_name ? fields.contact_last_name[0] : ''
 
     const contactProps = {
-      city: item.city ? item.city[0] : '',
+      city: fields.city ? fields.city[0] : '',
       streetAddress: this.formatStreetAddress(address1, address2),
-      state: item.state ? item.state[0] : '',
-      zipCode: item.zipcode ? item.zipcode[0] : '',
+      state: fields.state ? fields.state[0] : '',
+      zipCode: fields.zipcode ? fields.zipcode[0] : '',
       personTitle: this.formatName(firstName, lastName),
-      //email: item.contact_email ? item.contact_email[0] : '',
       email: '',
-      phoneNumber: item.bank_phone ? item.bank_phone[0] : '',
-      fax: item.contact_fax ? item.contact_fax[0] : '',
-      link: item.website ? item.website[0] : '',
+      phoneNumber: fields.bank_phone ? fields.bank_phone[0] : '',
+      fax: fields.contact_fax ? fields.contact_fax[0] : '',
+      link: fields.website ? fields.website[0] : '',
       border: false
     }
 
     const lenderDetailClassName = classNames({
-      [styles.detailView]: true,
-      [styles.additionalTitleMargin]: distance === null
+      [styles.detailView]: true
     })
 
     return (
       <div id="lender-detail" className={lenderDetailClassName} tabIndex="0">
         <div>
           <div>
-            <div className={styles.close}>
-              <img
-                onClick={() => hideDetailState()}
-                onKeyUp={obj => {
-                  const enterKeyCode = 13
-                  if (obj.keyCode === enterKeyCode) {
-                    hideDetailState()
-                  }
-                }}
-                src={exitIcon}
-                alt="close"
-                tabIndex="0"
-                aria-label="Closing this panel will take you back to the results list"
-                data-cy="close detail"
-              />
-            </div>
-            {distance !== null && (
-              <div className={'lender-distance ' + lenderResultStyles.distance}>
-                <div>
-                  <img src={marker} className={lenderResultStyles.marker} />
-                </div>
-                <div
-                  id="lender-miles"
-                  className={lenderResultStyles.miles}
-                  tabIndex="0"
-                  role="text"
-                >{`${Number(distance).toFixed(1)} miles`}</div>
-                <div className={lenderResultStyles.clear} />
-              </div>
-            )}
+            <div className={styles.close}></div>
             <h2 tabIndex="0" role="heading" className="lender-name">
-              {item.lender_name[0]}
+              {this.props.item.fields.lender_name[0]}
             </h2>
           </div>
         </div>

--- a/src/client/components/organisms/lender-detail/lender-detail.scss
+++ b/src/client/components/organisms/lender-detail/lender-detail.scss
@@ -1,6 +1,7 @@
 .detailView {
   width: 100%;
-  padding: 34px 30px;
+  border-bottom: $base-border;
+  padding: $base-spacing 30px;
   background: #ffffff;
   position: relative;
   &:focus {
@@ -20,6 +21,10 @@
       outline: 2px dotted $sba-gray-light;
       outline-offset: 3px;
     }
+  }
+
+  div[class~='contact-card'] {
+    margin-bottom: 0;
   }
 }
 

--- a/src/client/components/organisms/results/results.jsx
+++ b/src/client/components/organisms/results/results.jsx
@@ -218,6 +218,7 @@ class Results extends React.PureComponent {
     const view = shouldShowDetail
       ? this.renderDetailResultsView(resultsClassName)
       : this.renderResultsView(resultsClassName)
+    console.log('view', view)
     return (
       <div id={id} className={styles.container} role="main" aria-live="polite">
         {view}

--- a/src/client/components/organisms/results/results.jsx
+++ b/src/client/components/organisms/results/results.jsx
@@ -218,7 +218,6 @@ class Results extends React.PureComponent {
     const view = shouldShowDetail
       ? this.renderDetailResultsView(resultsClassName)
       : this.renderResultsView(resultsClassName)
-    console.log('view', view)
     return (
       <div id={id} className={styles.container} role="main" aria-live="polite">
         {view}

--- a/src/client/components/pages/lender-lookup-page/lender-lookup-page.jsx
+++ b/src/client/components/pages/lender-lookup-page/lender-lookup-page.jsx
@@ -3,7 +3,7 @@ import { isEmpty } from 'lodash'
 
 import styles from './lender-lookup-page.scss'
 import { StyleWrapperDiv, TextInput, MultiSelect } from 'atoms'
-import { PrimarySearchBar, Results, LenderDetail, LenderResult, OfficeMap } from 'organisms'
+import { PrimarySearchBar, Results, LenderDetail, OfficeMap } from 'organisms'
 import SearchTemplate from '../../templates/search/search.jsx'
 
 class LenderLookupPage extends React.PureComponent {
@@ -41,15 +41,6 @@ class LenderLookupPage extends React.PureComponent {
 
   setHoveredMarkerId(hoveredMarkerId) {
     this.setState({ hoveredMarkerId })
-  }
-
-  customDetailResultsView(resultsClassName, hideDetailState) {
-    const { selectedItem } = this.state
-    return (
-      <div className={resultsClassName}>
-        <LenderDetail selectedItem={selectedItem} hideDetailState={hideDetailState} />
-      </div>
-    )
   }
 
   render() {
@@ -147,12 +138,11 @@ class LenderLookupPage extends React.PureComponent {
             onResultHover={id => {
               this.setHoveredMarkerId(id)
             }}
-            customDetailResultsView={this.customDetailResultsView.bind(this)}
             extraContainerStyles={styles.centerContainer}
             extraResultContainerStyles={styles.resultContainer}
             setWhiteBackground
           >
-            <LenderResult />
+            <LenderDetail />
           </Results>
         </StyleWrapperDiv>
         <div className={styles.noticeWithLink}>

--- a/src/client/components/pages/lender-lookup-page/lender-lookup-page.scss
+++ b/src/client/components/pages/lender-lookup-page/lender-lookup-page.scss
@@ -90,6 +90,7 @@
   background-color: $secondary-blue-dark;
   color: $sba-blue-lighter;
   padding: $small-spacing;
+  padding-left: 28px;
   font-family: $serif-font-family;
   font-style: italic;
 

--- a/test/jest/client/components/pages/lender-lookup-page/lender-lookup-page.test.jsx
+++ b/test/jest/client/components/pages/lender-lookup-page/lender-lookup-page.test.jsx
@@ -39,6 +39,11 @@ describe('LenderLookupPage', () => {
       expect(wrapper.find('Results')).toHaveLength(1)
     })
 
+    it('renders LenderDetail inside Results', () => {
+      const wrapper = shallow(<LenderLookupPage />)
+      expect(wrapper.find('Results').find('LenderDetail')).toHaveLength(1)
+    })
+
     it('renders a notice with link to SBA District Office', () => {
       const wrapper = shallow(<LenderLookupPage />)
       expect(wrapper.find('.noticeWithLink')).toHaveLength(1)


### PR DESCRIPTION
- Surface the relevant information in lender results without requiring an extra click

- Adjust padding on banner to line up with other elements

<img width="296" alt="Screen Shot 2020-04-27 at 2 59 05 PM" src="https://user-images.githubusercontent.com/12025195/80409939-b49f4f00-8897-11ea-85c8-1b06fd1f9ed9.png">
