### PR TITLE
TC-74 Format Addresses in Search Results

### DIFF
--- a/src/client/components/molecules/lender-result-card/lender-result-card.jsx
+++ b/src/client/components/molecules/lender-result-card/lender-result-card.jsx
@@ -7,8 +7,15 @@ import classNames from 'classnames'
 const LenderResultCard = props => {
   const { link, phoneNumber, streetAddress, title, className: cn, testId, city, state, zipCode } = props
 
+  const makeFiveDigitZip = () => {
+    let fiveDigitZip = zipCode
+    while (fiveDigitZip.length < 5) {
+      fiveDigitZip = `0${fiveDigitZip}`
+    }
+    return fiveDigitZip
+  }
   const formatAddress = breakOrNewLine => {
-    return `${streetAddress}${breakOrNewLine}${city}, ${state} ${zipCode}`
+    return `${streetAddress}${breakOrNewLine}${city.toLowerCase()}, ${state} ${makeFiveDigitZip()}`
   }
 
   const fields = {
@@ -59,19 +66,14 @@ const LenderResultCard = props => {
           </h4>
         )}
         <div
+          className={styles.address}
           data-testid={fields.address.name}
           data-cy={fields.address.name}
-          className={styles.row}
           key={Math.random()}
         >
           <span dangerouslySetInnerHTML={{ __html: fields.address.text }} tabIndex="0" />
         </div>
-        <div
-          data-testid={fields.phoneNumber.name}
-          data-cy={fields.phoneNumber.name}
-          className={styles.row}
-          key={Math.random()}
-        >
+        <div data-testid={fields.phoneNumber.name} data-cy={fields.phoneNumber.name} key={Math.random()}>
           <span tabIndex="0">{fields.phoneNumber.text}</span>
         </div>
       </div>

--- a/src/client/components/molecules/lender-result-card/lender-result-card.scss
+++ b/src/client/components/molecules/lender-result-card/lender-result-card.scss
@@ -58,6 +58,10 @@
       }
     }
   }
+
+  .address {
+    text-transform: capitalize;
+  }
 }
 
 .box {

--- a/test/jest/client/components/molecules/lender-result-card/lender-result-card.test.jsx
+++ b/test/jest/client/components/molecules/lender-result-card/lender-result-card.test.jsx
@@ -7,9 +7,9 @@ describe('LenderResultCard', () => {
     link: 'sba.gov',
     phoneNumber: '301-792-0678',
     streetAddress: '3913 7th St NE',
-    city: 'Washington',
+    city: 'WASHINGTON',
     state: 'DC',
-    zipCode: '20015',
+    zipCode: '8091',
     title: 'Credit Union'
   }
   it('renders the passed title', () => {
@@ -18,13 +18,13 @@ describe('LenderResultCard', () => {
   })
 
   it('renders the address', () => {
-    const wrapper = mount(<LenderResultCard {...mockProps} />)
+    const wrapper = shallow(<LenderResultCard {...mockProps} />)
     const addressInnerHtml = wrapper
       .find('[data-testid="contact address"] span')
       .prop('dangerouslySetInnerHTML')
     expect(addressInnerHtml).toEqual(
       expect.objectContaining({
-        __html: '3913 7th St NE<br />Washington, DC 20015'
+        __html: '3913 7th St NE<br />washington, DC 08091'
       })
     )
   })


### PR DESCRIPTION
Transform all caps city names to capital case, make all zip codes 5 digits

![Screen Shot 2020-05-07 at 10 41 58 AM](https://user-images.githubusercontent.com/12025195/81308232-89fb8600-904f-11ea-9d54-30cdc7623b60.png)
