### PR TITLE
TA-3802 Use a different path to route to the download function

### DIFF
--- a/src/client/components/organisms/sbic-lookup/sbic-lookup.jsx
+++ b/src/client/components/organisms/sbic-lookup/sbic-lookup.jsx
@@ -7,7 +7,7 @@ import { Button, MultiSelect } from 'atoms'
 import { Paginator } from 'molecules'
 
 const pageSize = 10
-const SBIC_URL = '/api/content/sbic-contacts.csv'
+const SBIC_URL = '/download/sbic-contacts.csv'
 
 class SbicLookup extends React.Component {
   constructor(ownProps) {

--- a/src/server.js
+++ b/src/server.js
@@ -100,7 +100,7 @@ app.get('/health', (req, res, next) => {
 })
 
 const sbicContactsCsv = require('./controllers/sbic-contacts-csv.js')
-app.get('/api/content/sbic-contacts.csv', sbicContactsCsv.downloadCsv)
+app.get('/download/sbic-contacts.csv', sbicContactsCsv.downloadCsv)
 
 // this is only reached in local development where the nginx proxy is not present
 app.post('/api/feedback', (req, res, next) => {


### PR DESCRIPTION
Fixes: https://us-sba.atlassian.net/browse/TA-3802

Cloudfront directs requests to `/api/content/*` to an S3 bucket so our code to generate the CSV wasn't being used. Instead, it's likely the download button only worked before this because the CSV was manually entered into that bucket (it must have been deleted from the environments this was broken in). 

We already had code to generate the CSV programmatically from the Content API, so by changing the request to hit a different url we can now actually use that code to generate the CSV download. 😄 