### PR TITLE
TA-3849 disabled summary field

### DIFF
--- a/src/client/components/organisms/news-releases/news-releases.jsx
+++ b/src/client/components/organisms/news-releases/news-releases.jsx
@@ -47,11 +47,7 @@ class NewsReleases extends React.Component {
         {articles && articles.length > 0 && (
           <div className={styles.newsReleases} data-testid="news-cards">
             <h2>News releases</h2>
-            <DetailCardCollection
-              type={'article'}
-              cards={articles}
-              fieldsToShowInDetails={['Published', 'Summary']}
-            />
+            <DetailCardCollection type={'article'} cards={articles} fieldsToShowInDetails={['Published']} />
             <div className={styles.button} data-testid="news-more-button">
               <a href={articleLink}>
                 <Button primary>View All</Button>


### PR DESCRIPTION
for jira ticket https://us-sba.atlassian.net/browse/TA-3849

AC:
- [x] The summary no longer displays 
- [x] The red line remains

This change can be viewed at: https://avery.ussba.io/offices/district/6394/