### PR TITLE
TC-822 Prevent results from being cut off

### DIFF
--- a/src/client/components/pages/lender-lookup-page/lender-lookup-page.scss
+++ b/src/client/components/pages/lender-lookup-page/lender-lookup-page.scss
@@ -87,6 +87,7 @@
   min-width: 321px;
   padding-bottom: 71px;
   @include grid-media($sba-grid-medium) {
+    padding-bottom: 0;
     position: absolute;
     pointer-events: all;
   }

--- a/src/client/components/pages/office-lookup-page/office-lookup-page.jsx
+++ b/src/client/components/pages/office-lookup-page/office-lookup-page.jsx
@@ -118,19 +118,6 @@ class OfficeLookupPage extends React.PureComponent {
       type: defaultType
     }
 
-    const officeTypeTaxonomy = {
-      name: 'officeType',
-      terms: [
-        'SCORE Business Mentoring',
-        'Small Business Development Center',
-        'U.S. Export Assistance Center',
-        'Veteran’s Business Outreach Center',
-        'Women’s Business Center',
-        'Procurement Technical Assistance Center',
-        'Certified Development Company'
-      ]
-    }
-
     const officeServiceTaxonomy = this.getTaxonomy('officeService')
 
     const searchTips = [
@@ -227,7 +214,7 @@ class OfficeLookupPage extends React.PureComponent {
             customDetailResultsView={this.customDetailResultsView.bind(this)}
             extraContainerStyles={styles.centerContainer}
             extraResultContainerStyles={styles.resultContainer}
-            setWhiteBackground
+            setWhiteBackground={false}
             pageSize={5}
             totalOverride={50}
           >

--- a/src/client/components/pages/office-lookup-page/office-lookup-page.jsx
+++ b/src/client/components/pages/office-lookup-page/office-lookup-page.jsx
@@ -214,7 +214,7 @@ class OfficeLookupPage extends React.PureComponent {
             customDetailResultsView={this.customDetailResultsView.bind(this)}
             extraContainerStyles={styles.centerContainer}
             extraResultContainerStyles={styles.resultContainer}
-            setWhiteBackground={false}
+            setWhiteBackground={true}
             pageSize={5}
             totalOverride={50}
           >

--- a/src/client/components/pages/office-lookup-page/office-lookup-page.scss
+++ b/src/client/components/pages/office-lookup-page/office-lookup-page.scss
@@ -103,7 +103,9 @@
 
 .resultContainer {
   width: 100%;
+  padding-bottom: 55px;
   @include grid-media($sba-grid-large) {
+    padding-bottom: 0;
     position: absolute;
     pointer-events: all;
   }


### PR DESCRIPTION
`setWhiteBackground` prop was absolutely positioning the paginator causing it to obscure the last result in the list.